### PR TITLE
fix missing section tag

### DIFF
--- a/underactuated.html
+++ b/underactuated.html
@@ -3481,6 +3481,7 @@ Limited in number of dimensions.  Function approximation, but lacks convergence 
   no more expensive to compute!
 
   </p>
+</section>
 
 <section data-type="sect2"><h1>MDP approximations of deterministic, continuous-state systems</h1>
 


### PR DESCRIPTION
Spotted by @tkoolen 

This was breaking the table of contents layout and making some chapters inaccessible. 