### PR TITLE
Close paths and fix edgecolors on visualizers

### DIFF
--- a/src/pendulum_visualizer.py
+++ b/src/pendulum_visualizer.py
@@ -33,11 +33,11 @@ class PendulumVisualizer(PyPlotVisualizer):
 
         self.ax.set_xlim([-1.2, 1.2])
         self.ax.set_ylim([-1.2, 1.2])
-        self.base = self.ax.fill(self.base_x, self.base_y, zorder=1, color=(.3, .6, .4), edgecolor='k')
+        self.base = self.ax.fill(self.base_x, self.base_y, zorder=1, facecolor=(.3, .6, .4), edgecolor='k')
         # arm_x and arm_y are closed (last element == first element), but don't pass the
         # last element to the fill command, because it gets closed anyhow (and we want the
         # sizes to match for the update).
-        self.arm = self.ax.fill(self.arm_x[0:-1], self.arm_y[0:-1], zorder=0, color=(.9, .1, 0), edgecolor='k')
+        self.arm = self.ax.fill(self.arm_x[0:-1], self.arm_y[0:-1], zorder=0, facecolor=(.9, .1, 0), edgecolor='k')
         self.center_of_mass = self.ax.plot(0, -self.ac1, zorder=1, color='b', marker='o', markersize=14)
 
     def draw(self, context):

--- a/src/planar_rigid_body_visualizer.py
+++ b/src/planar_rigid_body_visualizer.py
@@ -113,7 +113,7 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
             viewPatches, viewColors = self.getViewPatches(body_i, tf)
             for patch, color in zip(viewPatches, viewColors):
                 self.body_fill_list += self.ax.fill(patch[0, :], patch[1, :], 
-                    zorder=0, color=color, edgecolor='k', closed=False)
+                    zorder=0, edgecolor='k', facecolor=color, closed=True)
 
     def buildViewPatches(self, use_random_colors):
         ''' Generates view patches. self.viewPatches stores a list
@@ -168,6 +168,7 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
                             # visualization. (This could be improved for 
                             # capsules?)
                             patch = geom.getPoints()
+
                     # Convert to homogenous coords and move out of body frame
                     patch = np.vstack((patch, np.ones((1, patch.shape[1]))))
                     patch = np.dot(element_local_tf, patch)
@@ -178,6 +179,11 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
                     if patch.shape[1] > 3:
                         hull = sp.spatial.ConvexHull(np.transpose(patch[0:2, :]))
                         patch = np.transpose(np.vstack([patch[:, v] for v in hull.vertices]))
+
+                    # Close path if not closed
+                    if (patch[:, -1] != patch[:, 0]).any():
+                        patch = np.hstack((patch, patch[:, 0][np.newaxis].T))
+
                     this_body_patches.append(patch)
                     if use_random_colors:
                         this_body_colors.append(next(color))
@@ -255,6 +261,7 @@ def setupValkyrieExample():
     # Valkyrie Example
     rbt = RigidBodyTree()
     world_frame = pydrake.rbtree.RigidBodyFrame("world_frame", rbt.world(), [0, 0, 0], [0, 0, 0])
+    from pydrake.multibody.parsers import PackageMap
     pmap = PackageMap()
     pmap.PopulateFromEnvironment("ROS_PACKAGE_PATH")
     drake_base_path = os.path.expandvars("${DRAKE_RESOURCE_ROOT}")


### PR DESCRIPTION
Also re-add packagemap, scoped only for the val setup, so that example works again.

![image](https://user-images.githubusercontent.com/3066703/35817989-dd5ad33e-0a6c-11e8-948b-ce5efa30b206.png)
![image](https://user-images.githubusercontent.com/3066703/35818013-ebd62fa8-0a6c-11e8-8678-ff507e3f9cec.png)

I'm not convinced this *ever* worked before!