### PR TITLE
fix installation instructions. appendix now has clickable mac/linux i…

### DIFF
--- a/scripts/continuous_integration/common/linux_ubuntu_xenial
+++ b/scripts/continuous_integration/common/linux_ubuntu_xenial
@@ -33,6 +33,8 @@ set -eux
 
 export DEBIAN_FRONTEND='noninteractive'
 
+yes | ./scripts/setup/linux/ubuntu/xenial/install_prereqs
+
 set +u
 if [ -z "${DRAKE_BINARY_URL}" ]; then
     DRAKE_BINARY_URL=`python -c "import sys, json; drake = json.load(open('drake_version.json')); print(drake['base_url'] + drake['build'] + '/drake-' + drake['version'] + '-xenial.tar.gz')"`
@@ -50,7 +52,5 @@ cat /opt/drake/share/doc/drake/VERSION.TXT && echo ""
 yes | /opt/drake/share/drake/setup/install_prereqs
 
 popd
-
-yes | ./scripts/setup/linux/ubuntu/xenial/install_prereqs
 
 

--- a/scripts/continuous_integration/common/linux_ubuntu_xenial
+++ b/scripts/continuous_integration/common/linux_ubuntu_xenial
@@ -33,8 +33,6 @@ set -eux
 
 export DEBIAN_FRONTEND='noninteractive'
 
-yes | ./scripts/setup/linux/ubuntu/xenial/install_prereqs
-
 set +u
 if [ -z "${DRAKE_BINARY_URL}" ]; then
     DRAKE_BINARY_URL=`python -c "import sys, json; drake = json.load(open('drake_version.json')); print(drake['base_url'] + drake['build'] + '/drake-' + drake['version'] + '-xenial.tar.gz')"`
@@ -49,5 +47,10 @@ rm -f drake.tar.gz
 
 cat /opt/drake/share/doc/drake/VERSION.TXT && echo ""
 
+yes | /opt/drake/share/drake/setup/install_prereqs
+
 popd
+
+yes | ./scripts/setup/linux/ubuntu/xenial/install_prereqs
+
 

--- a/scripts/continuous_integration/common/mac
+++ b/scripts/continuous_integration/common/mac
@@ -31,19 +31,21 @@
 
 set -eux
 
-./scripts/setup/mac/install_prereqs
-
 # load drake url from json
 readonly drake_url=`python -c "import sys, json; drake = json.load(open('drake_version.json')); print(drake['base_url'] + drake['build'] + '/drake-' + drake['version'] + '-mac.tar.gz')"`
 
-pushd /opt
+pushd /usr/local
 
 curl -o drake.tar.gz "${drake_url}"
 tar -xzf drake.tar.gz
 rm -f drake.tar.gz
 
-cat /opt/drake/share/doc/drake/VERSION.TXT
+cat ./drake/share/doc/drake/VERSION.TXT
+
+./drake/share/drake/setup/install_prereqs
 
 popd
+
+./scripts/setup/mac/install_prereqs
 
 

--- a/scripts/continuous_integration/common/mac
+++ b/scripts/continuous_integration/common/mac
@@ -31,6 +31,8 @@
 
 set -eux
 
+./scripts/setup/mac/install_prereqs
+
 # load drake url from json
 readonly drake_url=`python -c "import sys, json; drake = json.load(open('drake_version.json')); print(drake['base_url'] + drake['build'] + '/drake-' + drake['version'] + '-mac.tar.gz')"`
 
@@ -46,6 +48,5 @@ cat ./drake/share/doc/drake/VERSION.TXT
 
 popd
 
-./scripts/setup/mac/install_prereqs
 
 

--- a/scripts/setup/linux/ubuntu/xenial/install_prereqs
+++ b/scripts/setup/linux/ubuntu/xenial/install_prereqs
@@ -36,90 +36,20 @@ if [[ "${EUID}" -ne 0 ]]; then
   exit 1
 fi
 
-apt update -qq
-apt install -qq --no-install-recommends $(tr '\n' ' ' <<EOF
-curl
-software-properties-common
-EOF
-)
-
-add-apt-repository -s 'deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8'
-curl -L https://bazel.build/bazel-release.pub.gpg | apt-key add -
-
-add-apt-repository ppa:dreal/dreal
+# NOTE: Assumes that the drake (binary) install_prereqs script has already been run.  Only install additional components
 
 apt update -qq
 
 # Install development and Drake dependencies.
 apt install -qq --no-install-recommends $(tr '\n' ' ' <<EOF
-bazel
-bison
-ca-certificates
-clang-format-4.0
-cmake
-coinor-libclp-dev
-coinor-libipopt-dev
-flex
-g++
-git
-libboost-all-dev
-libbz2-dev
-libccd-dev
-libexpat1-dev
-libfreetype6-dev
-libgflags-dev
-libglib2.0-dev
-libglu1-mesa-dev
-libhdf5-dev
-libibex-dev
-libjpeg8-dev
-libjsoncpp-dev
-liblapack-dev
-liblz4-dev
-libnetcdf-cxx-legacy-dev
-libnetcdf-dev
-libnlopt-dev
-libogg-dev
-libpng12-dev
-libprotobuf-dev
-libqt5opengl5-dev
-libqt5x11extras5-dev
-libtheora-dev
-libtiff5-dev
-libtinyxml-dev
-libtinyxml2-dev
-libtool
-libxml2-dev
-libxt-dev
-libyaml-cpp-dev
-make
-openjdk-8-jdk
-openssh-client
-patchelf
-pkg-config
-protobuf-compiler
-python-dev
-python-gtk2
-python-lxml
 python-matplotlib
-python-numpy
-python-protobuf
-python-scipy
-python-tk
-python-yaml
-qt5-default
-zlib1g-dev
 EOF
 )
-
-curl -LO https://dl.bintray.com/dreal/dreal/dreal_4.17.12.2_amd64.deb
-trap 'rm -f dreal_4.17.12.2_amd64.deb' EXIT
-echo '9347492e47a518ff78991e15fe9de0cff0200573091385e42940cdbf1fcf77a5  dreal_4.17.12.2_amd64.deb' | sha256sum -c
-dpkg -i dreal_4.17.12.2_amd64.deb
 
 apt remove tidy libtidy-0.99-0
 curl -LO https://github.com/htacg/tidy-html5/releases/download/5.4.0/tidy-5.4.0-64bit.deb
 trap 'rm -rf tidy-5.4.0-64bit.deb' EXIT
 echo 'b6b971534ee6bacc68a7c5f9878b0a146fbd7f50c580db76a19823e8541f92f8  tidy-5.4.0-64bit.deb' | sha256sum -c
 dpkg -i tidy-5.4.0-64bit.deb
+
 

--- a/scripts/setup/linux/ubuntu/xenial/install_prereqs
+++ b/scripts/setup/linux/ubuntu/xenial/install_prereqs
@@ -36,20 +36,21 @@ if [[ "${EUID}" -ne 0 ]]; then
   exit 1
 fi
 
-# NOTE: Assumes that the drake (binary) install_prereqs script has already been run.  Only install additional components
+# NOTE: Assumes that the drake (binary) install_prereqs script will also be run.  Only install what we need to download drake and any additional requirements for this package.
 
 apt update -qq
 
 # Install development and Drake dependencies.
 apt install -qq --no-install-recommends $(tr '\n' ' ' <<EOF
+apt-transport-https
+curl
+python
 python-matplotlib
 EOF
 )
 
-apt remove tidy libtidy-0.99-0
+apt remove -qq tidy libtidy-0.99-0
 curl -LO https://github.com/htacg/tidy-html5/releases/download/5.4.0/tidy-5.4.0-64bit.deb
-trap 'rm -rf tidy-5.4.0-64bit.deb' EXIT
+trap 'rm -f tidy-5.4.0-64bit.deb' EXIT
 echo 'b6b971534ee6bacc68a7c5f9878b0a146fbd7f50c580db76a19823e8541f92f8  tidy-5.4.0-64bit.deb' | sha256sum -c
 dpkg -i tidy-5.4.0-64bit.deb
-
-

--- a/scripts/setup/mac/install_prereqs
+++ b/scripts/setup/mac/install_prereqs
@@ -50,37 +50,14 @@ if [[ ! -f /usr/include/expat.h || ! -f /usr/include/zlib.h ]]; then
   exit 3
 fi
 
-brew tap dreal-deps/coinor
-brew tap dreal-deps/ibex
-brew tap dreal/dreal
-brew tap robotlocomotion/director
+# NOTE: Assumes that the drake (binary) install_prereqs script has already been run.  Only install additional components
 
 brew update
 brew upgrade
 
 # Install development and Drake dependencies.
 brew install $(tr '\n' ' ' <<EOF
-bazel
-boost
-clang-format
-cmake
-dreal
-gflags
-glib
-ipopt
-libccd
-libyaml
-nlopt
-numpy
-pkg-config
-protobuf
-python
-scipy
 tidy-html5
-tinyxml
-tinyxml2
-vtk@8.0
-yaml-cpp
 EOF
 )
 
@@ -89,10 +66,7 @@ if [[ ! -f "${HOME}/.bazelrc" ]] || ! grep -q 'build --python_path=/usr/local/op
 fi
 
 pip2 install --upgrade $(tr '\n' ' ' <<EOF
-lxml
 matplotlib
-pip
-PyYAML
 EOF
 )
 

--- a/scripts/setup/mac/install_prereqs
+++ b/scripts/setup/mac/install_prereqs
@@ -50,7 +50,7 @@ if [[ ! -f /usr/include/expat.h || ! -f /usr/include/zlib.h ]]; then
   exit 3
 fi
 
-# NOTE: Assumes that the drake (binary) install_prereqs script has already been run.  Only install additional components
+# NOTE: Assumes that the drake (binary) install_prereqs script will also be run.  Only install what we need to download drake and any additional requirements for this package.
 
 brew update
 brew upgrade

--- a/underactuated.html
+++ b/underactuated.html
@@ -36,7 +36,7 @@
         return -1;
       }
 
-      function setPlatform(is_mac) {  // else mac
+      function setPlatform(is_mac) {  // else display linux
         if (is_mac) {
           to_show = document.getElementsByClassName("mac");
           to_hide = document.getElementsByClassName("linux");
@@ -6057,12 +6057,11 @@ export PYTHONPATH=/opt/drake/lib/python2.7/site-packages:${PYTHONPATH}</code></p
 
       <div class="mac"><pre class="highlight"><code>sudo tar -xvzf drake.tar.gz -C /opt
 /opt/drake/share/drake/setup/install_prereqs
-export PYTHONPATH=/opt/drake/lib/python2.7/site-packages:${PYTHONPATH}</code></pre></div>
+export PYTHONPATH=/opt/drake/lib/python2.7/site-packages:${PYTHONPATH}
+export PATH=/usr/local/opt/python/libexec/bin:${PATH}</code></pre></div>
     </section>
 
     <section data-type="sect2"><h1>Test for success</h1>
-
-      <p class="mac">NOTE: You must ensure that you have Homebrew Python installed, and are <a href="http://drake.mit.edu/python_bindings.html#using-the-python-bindings">using python2 from Homebrew Python</a> to execute these scripts, otherwise you python interpreter will crash in the test below.</p>
 
       <p><pre class="highlight"><code>python -c 'import pydrake; print(pydrake.__file__)'
 </code></pre></p>

--- a/underactuated.html
+++ b/underactuated.html
@@ -36,6 +36,22 @@
         return -1;
       }
 
+      function setPlatform(is_mac) {  // else mac
+        if (is_mac) {
+          to_show = document.getElementsByClassName("mac");
+          to_hide = document.getElementsByClassName("linux");
+        } else {
+          to_show = document.getElementsByClassName("linux");
+          to_hide = document.getElementsByClassName("mac");
+        }
+	for (i=0; i<to_show.length; i++) {
+          to_show[i].style.display = "inline";
+	}
+	for (i=0; i<to_hide.length; i++) {
+	  to_hide[i].style.display = "none";
+        }
+      }
+
       function revealChapters() {
         // generate table of contents
         {
@@ -50,6 +66,9 @@
           var part_number = 1;
 
           var list_of_drake_examples = "";
+
+	  // Set platform to linux unless I detect mac. 
+	  setPlatform(navigator.appVersion.indexOf("Mac")!=1);
 
           for (i = 0; i < chapters.length; i++) {
             var titles=chapters[i].getElementsByTagName("h1");
@@ -6001,19 +6020,17 @@ and Validation</h1>
   and recommended workflows to get you up and running quickly with the
   examples provided in these notes.</p>
 
+  <p>First, pick your platform:  <span class="linux"><b>Ubuntu</b> (shown)  |  <span onclick="setPlatform(true);" style="text-decoration:underline">Click here for Mac Homebrew</span></span><span class="mac"> <b>Mac Homebrew</b> (shown) | <span onclick="setPlatform(false);" style="text-decoration:underline">Click here for Ubuntu</span></span></p>
+
   <section data-type="sect1"><h1>Download the textbook supplement</h1>
 
     <div><pre class="highlight"><code>git clone https://github.com/RussTedrake/underactuated.git</code></pre></div>
 
     <p>and install the prerequisites using the platform-specific installation script provided:</p>
 
-    <todo>Show linux OR mac (hide on click).</todo>
+    <div class="linux"><pre class="highlight"><code>sudo underactuated/scripts/setup/linux/ubuntu/xenial/install_prereqs</code></pre></div>
 
-    <p><b>Linux</b>
-    <div><pre class="highlight"><code>sudo underactuated/scripts/setup/linux/ubuntu/xenial/install_prereqs</code></pre></div>
-
-    <p><b>Mac (using homebrew)</b></p>
-    <div><pre class="highlight"><code>underactuated/scripts/setup/mac/install_prereqs</code></pre></div>
+    <div class="mac"><pre class="highlight"><code>underactuated/scripts/setup/mac/install_prereqs</code></pre></div>
 
   </section>
 
@@ -6026,27 +6043,29 @@ and Validation</h1>
 
     <section data-type="sect2"><h1>Download the binaries</h1>
 
-      <todo>Show linux OR mac (hide on click).</todo>
+      <div class="linux"><pre class="highlight"><code>curl -o drake.tar.gz <div id="drake-linux-binaries" style="display:inline">https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz</div></code></pre></div>
 
-      <p><b>Linux</b>
-      <div><pre class="highlight"><code>curl -o drake.tar.gz <div id="drake-linux-binaries" style="display:inline">https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz</div></code></pre></div>
-
-      <p><b>Mac</b></p>
-      <div><pre class="highlight"><code>curl -o drake.tar.gz <div id="drake-mac-binaries" style="display:inline">https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz</div></code></pre></div>
+      <div class="mac"><pre class="highlight"><code>curl -o drake.tar.gz <div id="drake-mac-binaries" style="display:inline">https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz</div></code></pre></div>
 
     </section>
 
     <section data-type="sect2"><h1>Unpack and set your PYTHONPATH</h1>
 
-      <div><pre class="highlight"><code>sudo tar -xvzf drake.tar.gz -C /opt
-export PYTHONPATH=/opt/drake/install/lib/python2.7/site-packages:${PYTHONPATH}</code></pre></div>
+      <div class="linux"><pre class="highlight"><code>sudo tar -xvzf drake.tar.gz -C /opt
+sudo /opt/drake/share/drake/setup/install_prereqs
+export PYTHONPATH=/opt/drake/lib/python2.7/site-packages:${PYTHONPATH}</code></pre></div>
 
+      <div class="mac"><pre class="highlight"><code>sudo tar -xvzf drake.tar.gz -C /opt
+/opt/drake/share/drake/setup/install_prereqs
+export PYTHONPATH=/opt/drake/lib/python2.7/site-packages:${PYTHONPATH}</code></pre></div>
     </section>
 
     <section data-type="sect2"><h1>Test for success</h1>
 
-      <div><pre class="highlight"><code>python -c 'import pydrake; print(pydrake.__file__)'
-</code></pre></div>
+      <p class="mac">NOTE: You must ensure that you have Homebrew Python installed, and are <a href="http://drake.mit.edu/python_bindings.html#using-the-python-bindings">using python2 from Homebrew Python</a> to execute these scripts, otherwise you python interpreter will crash in the test below.</p>
+
+      <p><pre class="highlight"><code>python -c 'import pydrake; print(pydrake.__file__)'
+</code></pre></p>
 
       <p> Further tips and instructions are available at the <a
       href="http://drake.mit.edu/python_bindings.html#using-the-python-bindings">python


### PR DESCRIPTION
…nstructions.  underactuated install_prereqs now only has the reqs that are NOT in drake

Note: mac CI scripts are likely broken since the user can no longer write to /opt, but we don't need this right now.