### PR TITLE
Make underactuated_utils.findResource so can run examples outside of underactuated/src

### DIFF
--- a/src/double_pendulum_as_single_pendulum.py
+++ b/src/double_pendulum_as_single_pendulum.py
@@ -5,6 +5,7 @@ from pydrake.all import ( DiagramBuilder, FloatingBaseType, RigidBodyPlant,
                           RigidBodyTree, Simulator, VectorSystem )
 from planar_rigid_body_visualizer import PlanarRigidBodyVisualizer
 from manipulator_dynamics import *
+import underactuated_utils as utils
 
 class Controller(VectorSystem):
     """ Defines a feedback controller for the double pendulum.
@@ -44,7 +45,7 @@ class Controller(VectorSystem):
 
 
 # Load the double pendulum from Universal Robot Description Format
-tree = RigidBodyTree("double_pendulum.urdf", FloatingBaseType.kFixed)
+tree = RigidBodyTree(utils.findResource("double_pendulum.urdf"), FloatingBaseType.kFixed)
 
 # Set up a block diagram with the robot (dynamics), the controller, and a visualization block.
 builder = DiagramBuilder()

--- a/src/double_pendulum_manipulator.py
+++ b/src/double_pendulum_manipulator.py
@@ -1,7 +1,8 @@
 from pydrake.multibody.rigid_body_tree import RigidBodyTree
 from manipulator_dynamics import *
+import underactuated_utils as utils
 
-tree = RigidBodyTree("double_pendulum.urdf", FloatingBaseType.kFixed);
+tree = RigidBodyTree(utils.findResource("double_pendulum.urdf"), FloatingBaseType.kFixed);
 
 q = (1., 1.)
 v = (0.1, 0.1)

--- a/src/double_pendulum_simulator.ipynb
+++ b/src/double_pendulum_simulator.ipynb
@@ -34,6 +34,7 @@
     ")\n",
     "from planar_rigid_body_visualizer import PlanarRigidBodyVisualizer\n",
     "from manipulator_dynamics import manipulator_dynamics"
+    "import underactuated_utils as utils"
    ]
   },
   {
@@ -1662,7 +1663,7 @@
     "# renders a video of its results.\n",
     "\n",
     "# Load the double pendulum from Universal Robot Description Format\n",
-    "tree = RigidBodyTree(\"double_pendulum.urdf\", FloatingBaseType.kFixed)\n",
+    "tree = RigidBodyTree(utils.findResource(\"double_pendulum.urdf\"), FloatingBaseType.kFixed)\n",
     "\n",
     "# Set up a block diagram with the robot (dynamics) and a logger block.\n",
     "builder = DiagramBuilder()\n",

--- a/src/double_pendulum_simulator.py
+++ b/src/double_pendulum_simulator.py
@@ -1,9 +1,10 @@
 from pydrake.all import ( BasicVector, DiagramBuilder, FloatingBaseType,
                           RigidBodyPlant, RigidBodyTree, Simulator )
 from planar_rigid_body_visualizer import PlanarRigidBodyVisualizer
+import underactuated_utils as utils
 
 # Load the double pendulum from Universal Robot Description Format
-tree = RigidBodyTree("double_pendulum.urdf", FloatingBaseType.kFixed)
+tree = RigidBodyTree(utils.findResource("double_pendulum.urdf"), FloatingBaseType.kFixed)
 
 # Set up a block diagram with the robot (dynamics) and a visualization block.
 builder = DiagramBuilder()

--- a/src/underactuated_utils.py
+++ b/src/underactuated_utils.py
@@ -1,0 +1,4 @@
+import os
+
+def findResource(filename):
+   return os.path.join(os.path.dirname(__file__), filename)


### PR DESCRIPTION
I've already cloned `underactuated` into the docker image for class, and set PYTHONPATH

We just need to be able to find non-python files so that code examples in `underactuated/src` can run from anywhere, and this offers a findResource-style solution as discussed here: https://github.com/RussTedrake/underactuated/pull/58#issuecomment-363253150

Recommend adjustment to textbook as follows:

```python
from pydrake.all import ( BasicVector, DiagramBuilder, FloatingBaseType,
                          RigidBodyPlant, RigidBodyTree, Simulator )
from planar_rigid_body_visualizer import PlanarRigidBodyVisualizer
import underactuated_utils as utils

# Load the double pendulum from Universal Robot Description Format
tree = RigidBodyTree(utils.findResource("double_pendulum.urdf"), FloatingBaseType.kFixed)
```