### PR TITLE
only pause on native OSX

### DIFF
--- a/src/underactuated/pyplot_visualizer.py
+++ b/src/underactuated/pyplot_visualizer.py
@@ -45,7 +45,7 @@ class PyPlotVisualizer(LeafSystem):
     def _DoPublish(self, context, event):
         self.draw(context)
         self.fig.canvas.draw()
-        if plt.get_backend() != u'template':
+        if plt.get_backend() == u'MacOSX':
             plt.pause(1e-10)
 
     def draw(self, context):


### PR DESCRIPTION
This fixes OSX with docker (was previously making sim run very slow)

Has been tested on:

- OSX with docker
- linux with docker

Hasn't been tested on:

- native linux
- Windows with docker

Shouldn't affect:

- native OSX (same behavior for that)

----

also sorry I accidentally committed this to master, but then git reverted that, and made this PR
