### PR TITLE
[WIP] symbolic: Workaround for numpy#10876

### DIFF
--- a/src/lyapunov/cubic_polynomial.py
+++ b/src/lyapunov/cubic_polynomial.py
@@ -2,8 +2,8 @@ import math
 import numpy as np
 import matplotlib.pyplot as plt
 
-from pydrake.all import (Jacobian, MathematicalProgram, SolutionResult,
-                         Variables)
+from pydrake.all import (Expression, Jacobian, MathematicalProgram,
+                         SolutionResult, Variables)
 
 
 def dynamics(x):
@@ -12,16 +12,17 @@ def dynamics(x):
 
 prog = MathematicalProgram()
 x = prog.NewIndeterminates(1, "x")
+xe = x.astype(Expression)
 rho = prog.NewContinuousVariables(1, "rho")[0]
 
 # Define the Lyapunov function.
-V = x.dot(x)
+V = xe.dot(xe)
 Vdot = Jacobian([V], x).dot(dynamics(x))[0]
 
 # Define the Lagrange multipliers.
 (lambda_, constraint) = prog.NewSosPolynomial(Variables(x), 4)
 
-prog.AddSosConstraint((V-rho) * x.dot(x) - lambda_.ToExpression() * Vdot)
+prog.AddSosConstraint((V-rho) * xe.dot(xe) - lambda_.ToExpression() * Vdot)
 prog.AddLinearCost(-rho)
 
 result = prog.Solve()

--- a/src/lyapunov/linear_systems_common_lyapunov.py
+++ b/src/lyapunov/linear_systems_common_lyapunov.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pydrake.all import (MathematicalProgram, SolutionResult)
+from pydrake.all import (Expression, MathematicalProgram, SolutionResult)
 
 A = []
 if (True):
@@ -27,16 +27,17 @@ prog = MathematicalProgram()
 # variables.
 num_states = A[0].shape[0]
 P = prog.NewSymmetricContinuousVariables(num_states, "P")
+Pe = P.astype(Expression)
 prog.AddPositiveSemidefiniteConstraint(P - .01*np.identity(num_states))
 
 # Add the common Lyapunov conditions.
 for i in range(len(A)):
-    prog.AddPositiveSemidefiniteConstraint(-A[i].transpose().dot(P)
-                                           - P.dot(A[i])
+    prog.AddPositiveSemidefiniteConstraint(-A[i].transpose().dot(Pe)
+                                           - Pe.dot(A[i])
                                            - .01*np.identity(num_states))
 
 # Add an objective.
-prog.AddLinearCost(np.trace(P))
+prog.AddLinearCost(np.trace(Pe))
 
 # Run the optimization.
 result = prog.Solve()


### PR DESCRIPTION
Relates https://github.com/RobotLocomotion/drake/pull/8452

This works around numpy/numpy#10876 (numpy/numpy#9028) by explicitly using `Expression` with `np.dot`, since `np.dot` cannot be used with `Variable` as it is not closed under addition / subtraction.

This should be merged in if/when the above Drake PR lands.

This passes locally on my machine when using the following PR commit for NumPy: https://github.com/numpy/numpy/pull/10898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/113)
<!-- Reviewable:end -->
