### PR TITLE
PyPlot accepts figsize argument

### DIFF
--- a/src/underactuated/planar_rigid_body_visualizer.py
+++ b/src/underactuated/planar_rigid_body_visualizer.py
@@ -87,7 +87,6 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
                  facecolor=[1, 1, 1],
                  use_random_colors=False):
 
-
         default_size = matplotlib.rcParams['figure.figsize']
         scalefactor = (ylim[1]-ylim[0])/(xlim[1]-xlim[0])
         figsize = (default_size[0], default_size[0]*scalefactor)

--- a/src/underactuated/planar_rigid_body_visualizer.py
+++ b/src/underactuated/planar_rigid_body_visualizer.py
@@ -5,6 +5,7 @@ import math
 import os.path
 
 import numpy as np
+import matplotlib
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import scipy as sp
@@ -85,7 +86,13 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
                  ylim=[-1, 1],
                  facecolor=[1, 1, 1],
                  use_random_colors=False):
-        PyPlotVisualizer.__init__(self, facecolor=facecolor)
+
+
+        default_size = matplotlib.rcParams['figure.figsize']
+        scalefactor = (ylim[1]-ylim[0])/(xlim[1]-xlim[0])
+        figsize = (default_size[0], default_size[0]*scalefactor)
+
+        PyPlotVisualizer.__init__(self, facecolor=facecolor, figsize=figsize)
         self.set_name('planar_rigid_body_visualizer')
 
         self.rbtree = rbtree
@@ -102,9 +109,6 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
         # Achieve the desired view limits
         self.ax.set_xlim(xlim)
         self.ax.set_ylim(ylim)
-        default_size = self.fig.get_size_inches()
-        scalefactor = (ylim[1]-ylim[0])/(xlim[1]-xlim[0])
-        self.fig.set_size_inches(default_size[0], default_size[0]*scalefactor)
 
         # Populate body patches
         self.buildViewPatches(use_random_colors)

--- a/src/underactuated/pyplot_visualizer.py
+++ b/src/underactuated/pyplot_visualizer.py
@@ -8,6 +8,7 @@ from matplotlib.widgets import Slider
 from pydrake.all import (LeafSystem, PiecewisePolynomial, SignalLogger,
                          VectorSystem)
 
+
 class PyPlotVisualizer(LeafSystem):
     '''
         Base class from planar visualization
@@ -25,7 +26,7 @@ class PyPlotVisualizer(LeafSystem):
         input and draw the robot in the appropriate
         state.
     '''
-    
+
     def __init__(self, draw_timestep=0.033333, facecolor=[1, 1, 1],
                  figsize=None):
         LeafSystem.__init__(self)
@@ -35,7 +36,7 @@ class PyPlotVisualizer(LeafSystem):
         self._DeclarePeriodicPublish(draw_timestep, 0.0)
 
         (self.fig, self.ax) = plt.subplots(facecolor=facecolor,
-                                           figsize = figsize)
+                                           figsize=figsize)
         self.ax.axis('equal')
         self.ax.axis('off')
         self.fig.show()

--- a/src/underactuated/pyplot_visualizer.py
+++ b/src/underactuated/pyplot_visualizer.py
@@ -42,10 +42,8 @@ class PyPlotVisualizer(LeafSystem):
 
     def _DoPublish(self, context, event):
         self.draw(context)
-        self.fig.canvas.flush_events()
         self.fig.canvas.draw()
-        if plt.get_backend() == u'MacOSX':
-            plt.pause(1e-10)
+        plt.pause(1e-10)
 
     def draw(self, context):
         print "SUBCLASSES MUST IMPLEMENT."

--- a/src/underactuated/pyplot_visualizer.py
+++ b/src/underactuated/pyplot_visualizer.py
@@ -42,6 +42,7 @@ class PyPlotVisualizer(LeafSystem):
 
     def _DoPublish(self, context, event):
         self.draw(context)
+        self.fig.canvas.flush_events()
         self.fig.canvas.draw()
         if plt.get_backend() == u'MacOSX':
             plt.pause(1e-10)

--- a/src/underactuated/pyplot_visualizer.py
+++ b/src/underactuated/pyplot_visualizer.py
@@ -26,14 +26,16 @@ class PyPlotVisualizer(LeafSystem):
         state.
     '''
     
-    def __init__(self, draw_timestep=0.033333, facecolor=[1, 1, 1]):
+    def __init__(self, draw_timestep=0.033333, facecolor=[1, 1, 1],
+                 figsize=None):
         LeafSystem.__init__(self)
 
         self.set_name('pyplot_visualization')
         self.timestep = draw_timestep
         self._DeclarePeriodicPublish(draw_timestep, 0.0)
 
-        (self.fig, self.ax) = plt.subplots(facecolor=facecolor)
+        (self.fig, self.ax) = plt.subplots(facecolor=facecolor,
+                                           figsize = figsize)
         self.ax.axis('equal')
         self.ax.axis('off')
         self.fig.show()


### PR DESCRIPTION
Follows up on #118 to hopefully work better on Mac

Also adds what I *hope* is an innocuous additional flush_events call to remedy issues I've had on Ubuntu 16.04 getting plots to open up. This could also be fixed by always calling plt.pause()... that may be the cleaner route, even if it is a little less performant on some platforms.