### PR TITLE
Allow passthrough of ax and fig to pyplotvisualizer

### DIFF
--- a/src/underactuated/planar_rigid_body_visualizer.py
+++ b/src/underactuated/planar_rigid_body_visualizer.py
@@ -85,13 +85,16 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
                  xlim=[-1., 1],
                  ylim=[-1, 1],
                  facecolor=[1, 1, 1],
-                 use_random_colors=False):
+                 use_random_colors=False,
+                 fig=None,
+                 ax=None):
 
         default_size = matplotlib.rcParams['figure.figsize']
         scalefactor = (ylim[1]-ylim[0])/(xlim[1]-xlim[0])
         figsize = (default_size[0], default_size[0]*scalefactor)
 
-        PyPlotVisualizer.__init__(self, facecolor=facecolor, figsize=figsize)
+        PyPlotVisualizer.__init__(self, facecolor=facecolor, figsize=figsize,
+                                  fig=fig, ax=ax)
         self.set_name('planar_rigid_body_visualizer')
 
         self.rbtree = rbtree
@@ -111,6 +114,11 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
         # Achieve the desired view limits
         self.ax.set_xlim(xlim)
         self.ax.set_ylim(ylim)
+        if self.fig is not None:
+            default_size = self.fig.get_size_inches()
+            scalefactor = (ylim[1]-ylim[0])/(xlim[1]-xlim[0])
+            self.fig.set_size_inches(default_size[0],
+                                     default_size[0]*scalefactor)
 
         # Populate body patches
         self.buildViewPatches(use_random_colors)

--- a/src/underactuated/planar_rigid_body_visualizer.py
+++ b/src/underactuated/planar_rigid_body_visualizer.py
@@ -51,6 +51,13 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
         - facecolor is passed through to figure() and sets
         background color. Both color name strings and
         RGB triplets are allowed. Defaults to white.
+        - use_random_colors, if set to True, will render
+        each body with a different color. (Multiple visual
+        elements on the same body will be the same color.)
+        - if ax is supplied, the visualizer will draw
+        onto those axes instead of creating a new
+        set of axes. The visualizer will still change
+        the view range and figure size of those axes.
 
         Specifics on view setup:
 
@@ -86,7 +93,6 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
                  ylim=[-1, 1],
                  facecolor=[1, 1, 1],
                  use_random_colors=False,
-                 fig=None,
                  ax=None):
 
         default_size = matplotlib.rcParams['figure.figsize']
@@ -94,7 +100,7 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
         figsize = (default_size[0], default_size[0]*scalefactor)
 
         PyPlotVisualizer.__init__(self, facecolor=facecolor, figsize=figsize,
-                                  fig=fig, ax=ax)
+                                  ax=ax)
         self.set_name('planar_rigid_body_visualizer')
 
         self.rbtree = rbtree
@@ -114,11 +120,10 @@ class PlanarRigidBodyVisualizer(PyPlotVisualizer):
         # Achieve the desired view limits
         self.ax.set_xlim(xlim)
         self.ax.set_ylim(ylim)
-        if self.fig is not None:
-            default_size = self.fig.get_size_inches()
-            scalefactor = (ylim[1]-ylim[0])/(xlim[1]-xlim[0])
-            self.fig.set_size_inches(default_size[0],
-                                     default_size[0]*scalefactor)
+        default_size = self.fig.get_size_inches()
+        scalefactor = (ylim[1]-ylim[0])/(xlim[1]-xlim[0])
+        self.fig.set_size_inches(default_size[0],
+                                 default_size[0]*scalefactor)
 
         # Populate body patches
         self.buildViewPatches(use_random_colors)
@@ -279,8 +284,9 @@ def setupDoublePendulumExample():
                         floating_base_type=FloatingBaseType.kFixed)  # noqa
     Tview = np.array([[1., 0., 0., 0.], [0., 0., 1., 0.], [0., 0., 0., 1.]],
                      dtype=np.float64)
+    fig, ax = plt.subplots(1, 1)
     pbrv = PlanarRigidBodyVisualizer(rbt, Tview, [-2.5, 2.5], [-2.5, 2.5],
-                                     use_random_colors=True)
+                                     use_random_colors=True, ax=ax)
     return rbt, pbrv
 
 

--- a/src/underactuated/pyplot_visualizer.py
+++ b/src/underactuated/pyplot_visualizer.py
@@ -17,6 +17,9 @@ class PyPlotVisualizer(LeafSystem):
         In the configuration set up here,
         this visualizer provides one visualization
         window (self.fig) with axes (self.ax).
+        The axes can optionally be supplied externally to
+        allow other visualizers to overlay additional
+        information.
 
         Subclasses must:
         - During initialization, set up the figure
@@ -28,7 +31,7 @@ class PyPlotVisualizer(LeafSystem):
     '''
 
     def __init__(self, draw_timestep=0.033333, facecolor=[1, 1, 1],
-                 figsize=None, fig=None, ax=None):
+                 figsize=None, ax=None):
         LeafSystem.__init__(self)
 
         self.set_name('pyplot_visualization')
@@ -36,25 +39,20 @@ class PyPlotVisualizer(LeafSystem):
         self._DeclarePeriodicPublish(draw_timestep, 0.0)
 
         if ax is None:
-            if fig is not None:
-                print "Error: supplied fig but not ax."
             (self.fig, self.ax) = plt.subplots(facecolor=facecolor,
                                                figsize=figsize)
         else:
-            self.fig = fig
             self.ax = ax
+            self.fig = ax.get_figure()
 
         self.ax.axis('equal')
         self.ax.axis('off')
-
-        if self.fig is not None:
-            self.fig.show()
+        self.fig.show()
 
     def _DoPublish(self, context, event):
         self.draw(context)
-        if self.fig is not None:
-            self.fig.canvas.draw()
-            plt.pause(1e-10)
+        self.fig.canvas.draw()
+        plt.pause(1e-10)
 
     def draw(self, context):
         print "SUBCLASSES MUST IMPLEMENT."

--- a/src/underactuated/pyplot_visualizer.py
+++ b/src/underactuated/pyplot_visualizer.py
@@ -28,21 +28,33 @@ class PyPlotVisualizer(LeafSystem):
     '''
 
     def __init__(self, draw_timestep=0.033333, facecolor=[1, 1, 1],
-                 figsize=None):
+                 figsize=None, fig=None, ax=None):
         LeafSystem.__init__(self)
 
         self.set_name('pyplot_visualization')
         self.timestep = draw_timestep
         self._DeclarePeriodicPublish(draw_timestep, 0.0)
 
-        (self.fig, self.ax) = plt.subplots(facecolor=facecolor,
-                                           figsize=figsize)
-        self.fig.show()
+        if ax is None:
+            if fig is not None:
+                print "Error: supplied fig but not ax."
+            (self.fig, self.ax) = plt.subplots(facecolor=facecolor,
+                                               figsize=figsize)
+        else:
+            self.fig = fig
+            self.ax = ax
+
+        self.ax.axis('equal')
+        self.ax.axis('off')
+
+        if self.fig is not None:
+            self.fig.show()
 
     def _DoPublish(self, context, event):
         self.draw(context)
-        self.fig.canvas.draw()
-        plt.pause(1e-10)
+        if self.fig is not None:
+            self.fig.canvas.draw()
+            plt.pause(1e-10)
 
     def draw(self, context):
         print "SUBCLASSES MUST IMPLEMENT."


### PR DESCRIPTION
This opens the door for the pyplotvisualizer to be layered on top of other visualization that shares the sample view -- I've used this for testing some perception stuff and plan to use it in Set 5 to try to visualizer some subset of contact forces and pose goals.