### PR TITLE
Meshcat now uses colors and disambiguates body names

### DIFF
--- a/src/underactuated/__init__.py
+++ b/src/underactuated/__init__.py
@@ -1,3 +1,4 @@
+from meshcat_rigid_body_visualizer import MeshcatRigidBodyVisualizer
 from planar_rigid_body_visualizer import PlanarRigidBodyVisualizer
 from pyplot_visualizer import (PyPlotVisualizer, SliderSystem)
 from rigid_body_tree import ManipulatorDynamics

--- a/src/underactuated/meshcat_rigid_body_visualizer.py
+++ b/src/underactuated/meshcat_rigid_body_visualizer.py
@@ -80,7 +80,7 @@ class MeshcatRigidBodyVisualizer(LeafSystem):
         for body_i in range(n_bodies):
 
             body = self.rbtree.get_body(body_i+1)
-            body_name = body.get_name()
+            body_name = body.get_name() + ("(%d)" % body_i)
 
             visual_elements = body.get_visual_elements()
             this_body_patches = []
@@ -117,9 +117,19 @@ class MeshcatRigidBodyVisualizer(LeafSystem):
                               geom.getShape(), " IGNORED"
                         continue
 
+                    def rgba2hex(rgba):
+                        ''' Turn a list of R,G,B elements (any indexable
+                        list of >= 3 elements will work), where each element
+                        is specified on range [0., 1.], into the equivalent
+                        24-bit value 0xRRGGBB. '''
+                        val = 0.
+                        for i in range(3):
+                            val += (256**(2 - i)) * (255. * rgba[i])
+                        return val
                     self.vis[body_name][str(element_i)].set_object(
-                        meshcat_geom)
-                    print body_name, element_i, element_local_tf
+                        meshcat_geom,
+                        meshcat.geometry.MeshLambertMaterial(
+                            color=rgba2hex(element.getMaterial())))
                     self.vis[body_name][str(element_i)].set_transform(
                         element_local_tf)
 
@@ -140,7 +150,8 @@ class MeshcatRigidBodyVisualizer(LeafSystem):
         body_fill_index = 0
         for body_i in range(self.rbtree.get_num_bodies()-1):
             tf = self.rbtree.relativeTransform(kinsol, 0, body_i+1)
-            body_name = self.rbtree.get_body(body_i+1).get_name()
+            body_name = self.rbtree.get_body(body_i+1).get_name() \
+                + ("(%d)" % body_i)
             self.vis[body_name].set_transform(tf)
 
     def animate(self, log, resample=True):

--- a/src/underactuated/meshcat_rigid_body_visualizer.py
+++ b/src/underactuated/meshcat_rigid_body_visualizer.py
@@ -80,6 +80,10 @@ class MeshcatRigidBodyVisualizer(LeafSystem):
         for body_i in range(n_bodies):
 
             body = self.rbtree.get_body(body_i+1)
+            # TODO(gizatt) Replace these body-unique indices
+            # with more readable body.get_model_name() or other
+            # model index information when an appropriate
+            # function gets bound in pydrake.
             body_name = body.get_name() + ("(%d)" % body_i)
 
             visual_elements = body.get_visual_elements()

--- a/src/underactuated/meshcat_rigid_body_visualizer.py
+++ b/src/underactuated/meshcat_rigid_body_visualizer.py
@@ -121,14 +121,14 @@ class MeshcatRigidBodyVisualizer(LeafSystem):
                               geom.getShape(), " IGNORED"
                         continue
 
-                    def rgba2hex(rgba):
+                    def rgba2hex(rgb):
                         ''' Turn a list of R,G,B elements (any indexable
                         list of >= 3 elements will work), where each element
                         is specified on range [0., 1.], into the equivalent
                         24-bit value 0xRRGGBB. '''
                         val = 0.
                         for i in range(3):
-                            val += (256**(2 - i)) * (255. * rgba[i])
+                            val += (256**(2 - i)) * (255. * rgb[i])
                         return val
                     self.vis[body_name][str(element_i)].set_object(
                         meshcat_geom,


### PR DESCRIPTION
I had some trouble in an example where multiple identical robots were added to the same scene -- they have different model #'s but the same body names. As a stopgap, this appends body names (for visualization only) with their unique body index.  A TODO in the code describes that this ought to be made more human-readable when rigid_body.get_model_name() gets bound to Python.

Also, now the meshcat viz uses the VisualElement material color. 

![image](https://user-images.githubusercontent.com/3066703/40392946-8949824a-5deb-11e8-8910-ed0bb1dd8479.png)
