### PR TITLE
ipykernel install started failing on CI.  this pegs the version.

### DIFF
--- a/scripts/setup/ubuntu/16.04/install_prereqs
+++ b/scripts/setup/ubuntu/16.04/install_prereqs
@@ -56,6 +56,7 @@ EOF
 )
 
 pip install --upgrade --disable-pip-version-check $(tr '\n' ' ' <<EOF
+ipykernel==4.8.2
 jupyter
 pycodestyle
 meshcat

--- a/scripts/setup/ubuntu/16.04/install_prereqs
+++ b/scripts/setup/ubuntu/16.04/install_prereqs
@@ -56,6 +56,7 @@ EOF
 )
 
 pip install --upgrade --disable-pip-version-check $(tr '\n' ' ' <<EOF
+ipython==5.8.0
 ipykernel==4.8.2
 jupyter
 pycodestyle


### PR DESCRIPTION
Per jamiesnape:
Looks like jupyter is a metapackage that depends on

notebook
qtconsole
jupyter-console
nbconvert
ipykernel
ipywidgets

and ipykernel changed from 4.8.2 to 4.9 on August 29.

Do you need all those components? If not, maybe replace the pip install jupyter with pip install nbconvert, etc.

Alternatively, install all the components, but try pinning the version of ipykernel to 4.8.2 for now.