### PR TITLE
Flag to filter transparent geometries from meshcat_visualizer

### DIFF
--- a/src/underactuated/meshcat_visualizer.py
+++ b/src/underactuated/meshcat_visualizer.py
@@ -56,7 +56,8 @@ class MeshcatVisualizer(LeafSystem):
                  scene_graph,
                  draw_timestep=0.033333,
                  prefix="SceneGraph",
-                 zmq_url="tcp://127.0.0.1:6000"):
+                 zmq_url="tcp://127.0.0.1:6000",
+                 min_alpha=0.0):
         LeafSystem.__init__(self)
 
         self.set_name('Meshcat')
@@ -69,6 +70,7 @@ class MeshcatVisualizer(LeafSystem):
 
         # Set up meshcat.
         self.prefix = prefix
+        self.min_alpha = min_alpha
         self.vis = meshcat.Visualizer(zmq_url=zmq_url)
         self.vis[self.prefix].delete()
         self._scene_graph = scene_graph
@@ -91,6 +93,10 @@ class MeshcatVisualizer(LeafSystem):
 
             for j in range(link.num_geom):
                 geom = link.geom[j]
+                alpha = geom.color[3]
+                if alpha < self.min_alpha:
+                    continue
+
                 element_local_tf = RigidTransform(
                     RotationMatrix(Quaternion(geom.quaternion)),
                     geom.position).GetAsMatrix4()


### PR DESCRIPTION
The meshcat_visualizer is currently drawing both visual and collision elements. Collision elements seem to have a rgba color of (0, 0, 0, 0). Because meshcat doesn't support transparency (as far as I can tell), the collision geometries are visible, black, and opaque. My simple workaround for this is to filter geometries with low alpha values.

Before
![image](https://user-images.githubusercontent.com/3621061/47856343-59cd8a00-ddbd-11e8-8757-940c0af16606.png)

After
![image](https://user-images.githubusercontent.com/3621061/47856809-7ae2aa80-ddbe-11e8-9bcd-12aa0e3a513c.png)
