### PR TITLE
underactuated: Use Drake nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,14 @@ jobs:
           name: build and test
           command: ./scripts/continuous_integration/circle_ci/build_test
 
-  underactuated-with-drake-continuous:
+  underactuated-with-drake-nightly:
     docker:
       - image: robotlocomotion/circleci:xenial
 
     working_directory: ~/underactuated
 
     environment:
-      - DRAKE_BINARY_URL: "https://drake-packages.csail.mit.edu/drake/continuous/drake-latest-xenial.tar.gz"
+      - DRAKE_BINARY_URL: "https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz"
 
     steps:
       - checkout
@@ -61,4 +61,4 @@ workflows:
             branches:
               only: master
     jobs:
-       - underactuated-with-drake-continuous
+       - underactuated-with-drake-nightly


### PR DESCRIPTION
This error:
https://circleci.com/gh/RussTedrake/underactuated/830?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification
Arose due to a packaging error in `continuous`. From slack:
> Confirmed that it was a packaging error.
> If I download the continuous package:
> `curl https://drake-packages.csail.mit.edu/drake/continuous/drake-20181219205130-fdd7553c31bd45c467bc1af0e6de6ee56c36ab41-xenial.tar.gz -O`
> And I go to `lib/python2.7/site-packages/pydrake`:
> ```$ find . -name 'ik.so'
> ./attic/solvers/ik.so
> ./solvers/ik.so
> ```
> I did not get this install tree when rebuilding from source.

I'd suggest that this use nightlies, as they're what we document and (I'd guess) more likely to be stable.

\cc @jamiesnape

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/154)
<!-- Reviewable:end -->
