### PR TITLE
Update install_prereq to prefer tornado < 6 for Python 2 support

### DIFF
--- a/scripts/setup/ubuntu/16.04/install_prereqs
+++ b/scripts/setup/ubuntu/16.04/install_prereqs
@@ -61,6 +61,7 @@ ipykernel==4.8.2
 jupyter
 pycodestyle
 meshcat
+tornado<6
 EOF
 )
 


### PR DESCRIPTION
(Seeing how CI feels about this)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/175)
<!-- Reviewable:end -->
