### PR TITLE
 setup: Update script to encourage use of hashsums

### DIFF
--- a/scripts/setup/jupyter_setup.py
+++ b/scripts/setup/jupyter_setup.py
@@ -1,11 +1,36 @@
+"""
+Provides setup scripts for provisioning Drake and Underactuated, especially for
+use on Google Collaboratory.
+
+For security, this script should never be downloaded and executed without
+performing a simple hashsum check, and should always use a pinned Git SHA1.
+
+To compute the hashsum for this script at a given commit::
+
+    git rev-parse --short HEAD  # Ensure your changes are committed!
+    sha256sum jupyter_setup.py  # Copy the checksum
+
+This output should then be included in the check of the hashsum when this
+script is later downloaded, using ``sha256sum -c``.
+"""
+
 import sys
 import platform
 from IPython import get_ipython
 
-def setup_drake():
-    """ Install drake (if necessary) and set up the path.
+# TODO(eric): Either provide optional checksum of archive here, or figure out
+# other provisioning mechanism.
 
-        On Google's Colab:
+def setup_drake(date):
+    """
+    Install drake (if necessary) and set up the path. For more information on
+    dates, see https://drake.mit.edu/from_binary.html#nightly-releases
+
+    Note:
+        At present, this will not check if the existing Drake install is from
+        the given date.
+
+    On Google's Colab:
         This will take a minute, but should only need to reinstall once
         every 12 hours. Colab will ask you to "Reset all runtimes", say no to
         save yourself the reinstall.
@@ -14,26 +39,30 @@ def setup_drake():
         import pydrake
     except ImportError:
         if platform.system() is 'Darwin':
-            get_ipython().system(u'if [ ! -d "/opt/drake" ]; then curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/continuous/drake-latest-mac.tar.gz && tar -xzf drake.tar.gz -C /opt && /opt/drake/share/drake/setup/install_prereqs; fi')
+            get_ipython().system(u'if [ ! -d "/opt/drake" ]; then curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/continuous/drake-{date}-mac.tar.gz && tar -xzf drake.tar.gz -C /opt && /opt/drake/share/drake/setup/install_prereqs; fi'.format(date=date))
         else:
-            get_ipython().system(u'if [ ! -d "/opt/drake" ]; then curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/continuous/drake-latest-bionic.tar.gz && tar -xzf drake.tar.gz -C /opt && /opt/drake/share/drake/setup/install_prereqs; fi')
+            get_ipython().system(u'if [ ! -d "/opt/drake" ]; then curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/continuous/drake-{date}-bionic.tar.gz && tar -xzf drake.tar.gz -C /opt && /opt/drake/share/drake/setup/install_prereqs; fi'.format(date=date))
         sys.path.append("/opt/drake/lib/python2.7/site-packages/")
 
-def setup_underactuated():
-    """ Install underactuated (if necessary) and set up the path.
+def setup_underactuated(commit, drake_date):
+    """
+    Install underactuated (if necessary) and set up the path.
 
-        On Google's Colab:
+    Note:
+        At present, this will not check if the existing version is at the given
+        commit.
+
+    On Google's Colab:
         This will take a minute, but should only need to reinstall once
         every 12 hours. Colab will ask you to "Reset all runtimes", say no to
         save yourself the reinstall.
     """
-    setup_drake()
+    setup_drake(date=drake_date)
     try:
         import underactuated
     except ImportError:
         if platform.system() is 'Darwin':
-            get_ipython().system(u'if [ ! -d "/opt/underactuated" ]; then git clone https://github.com/RussTedrake/underactuated.git /opt/underactuated && /opt/underactuated/scripts/setup/mac/install_prereqs; fi')
+            get_ipython().system(u'if [ ! -d "/opt/underactuated" ]; then git clone https://github.com/RussTedrake/underactuated.git /opt/underactuated && git checkout {commit} && /opt/underactuated/scripts/setup/mac/install_prereqs; fi'.format(commit=commit))
         else:
-            get_ipython().system(u'if [ ! -d "/opt/underactuated" ]; then git clone https://github.com/RussTedrake/underactuated.git /opt/underactuated && /opt/underactuated/scripts/setup/ubuntu/16.04/install_prereqs; fi')
+            get_ipython().system(u'if [ ! -d "/opt/underactuated" ]; then git clone https://github.com/RussTedrake/underactuated.git /opt/underactuated && git checkout {commit} && /opt/underactuated/scripts/setup/ubuntu/16.04/install_prereqs; fi'.format(commit=commit))
         sys.path.append("/opt/underactuated/src")
-

--- a/src/mathematical_program_examples.ipynb
+++ b/src/mathematical_program_examples.ipynb
@@ -6,15 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install drake (if necessary) and set up the path.  \n",
+    "# Install drake and the underactuated source repo (only if necessary) and set up the path.  Run this first!\n",
     "try:\n",
-    "  import pydrake\n",
+    "    import pydrake\n",
+    "    import underactuated\n",
     "except ImportError:\n",
-    "  !curl -s https://raw.githubusercontent.com/RussTedrake/underactuated/master/scripts/setup/jupyter_setup.py > jupyter_setup.py\n",
-    "  from jupyter_setup import setup_drake\n",
-    "  setup_drake()\n",
-    "# Note: On Google's Colaboratory, this will take a minute, but should only need to reinstall once every 12 hours.\n",
-    "# Colab will ask you to \"Reset all runtimes\"; say no to save yourself the reinstall."
+    "    # See docstring in `jupyter_setup.py` for how to update.\n",
+    "    _commit, _checksum = \"1e1bf57\", \"4ec422f0602a7391701dab26863af25b7bc9aa111c57008366de8abce8ea65dc\"\n",
+    "    !curl -s https://raw.githubusercontent.com/EricCousineau-TRI/underactuated/{_commit}/scripts/setup/jupyter_setup.py > jupyter_setup.py\n",
+    "    _result = !echo {_checksum} jupyter_setup.py | sha256sum -c; echo $?\n",
+    "    assert _result[-1] == '0', \"\\n\".join(_result)\n",
+    "    from jupyter_setup import setup_underactuated\n",
+    "    # Note: On Google's Colaboratory, this will take a minute, but should only need to reinstall once every 12 hours.\n",
+    "    # Colab will ask you to \"Reset all runtimes\"; say no to save yourself the reinstall.\n",
+    "    setup_underactuated(commit=\"master\", drake_date=\"latest\")"
    ]
   },
   {

--- a/src/underactuated_scratchpad.ipynb
+++ b/src/underactuated_scratchpad.ipynb
@@ -14,24 +14,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Install drake and the underactuated source repo (only if necessary) and set up the path.  Run this first!\n",
     "try:\n",
-    "  import pydrake\n",
-    "  import underactuated\n",
+    "    import pydrake\n",
+    "    import underactuated\n",
     "except ImportError:\n",
-    "  !curl -s https://raw.githubusercontent.com/RussTedrake/underactuated/master/scripts/setup/jupyter_setup.py > jupyter_setup.py\n",
-    "  from jupyter_setup import setup_underactuated\n",
-    "  setup_underactuated()\n",
-    "# Note: On Google's Colaboratory, this will take a minute, but should only need to reinstall once every 12 hours.\n",
-    "# Colab will ask you to \"Reset all runtimes\"; say no to save yourself the reinstall.\n",
-    "\n",
+    "    # See docstring in `jupyter_setup.py` for how to update.\n",
+    "    _commit, _checksum = \"1e1bf57\", \"4ec422f0602a7391701dab26863af25b7bc9aa111c57008366de8abce8ea65dc\"\n",
+    "    !curl -s https://raw.githubusercontent.com/EricCousineau-TRI/underactuated/{_commit}/scripts/setup/jupyter_setup.py > jupyter_setup.py\n",
+    "    _result = !echo {_checksum} jupyter_setup.py | sha256sum -c; echo $?\n",
+    "    assert _result[-1] == '0', \"\\n\".join(_result)\n",
+    "    from jupyter_setup import setup_underactuated\n",
+    "    # Note: On Google's Colaboratory, this will take a minute, but should only need to reinstall once every 12 hours.\n",
+    "    # Colab will ask you to \"Reset all runtimes\"; say no to save yourself the reinstall.\n",
+    "    setup_underactuated(commit=\"master\", drake_date=\"latest\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Toy code to show that things worked.\n",
     "import os\n",
-    "import underactuated\n", 
-    "underactuated_src_dir = os.path.dirname(os.path.dirname(os.path.abspath(underactuated.__file__)))"
+    "import underactuated\n",
+    "underactuated_src_dir = os.path.dirname(os.path.dirname(os.path.abspath(underactuated.__file__)))\n",
+    "print(underactuated_src_dir)"
    ]
   },
   {


### PR DESCRIPTION
This took way longer than desired due to the fact that IPython's system shell silently eats errors.

In general, users should be encouraged to (a) pin versions of provisioning scripts and (b) know if the provisioning script changed. They can elect to ignore it, but it'd be nice to not encourage the negative form of this?

Overall, I don't think this current provisioning system is very sustainable; possibly later (Q3 or Q4) we should more seriously consider some other provisioning mechanism.

Proposed PR process:
* We look at the overall noise that gets introduced, and see if it's worth the effort.
* We merge the first commit, then update the commit + hashsum in the notebooks, and merge that separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/195)
<!-- Reviewable:end -->
