### PR TITLE
Add Double Integrator Visualization

### DIFF
--- a/src/double_integrator/CMakeLists.txt
+++ b/src/double_integrator/CMakeLists.txt
@@ -1,2 +1,3 @@
 
 add_pytest(value_iteration.py)
+add_pytest(visualizer.py)

--- a/src/double_integrator/value_iteration.py
+++ b/src/double_integrator/value_iteration.py
@@ -15,7 +15,7 @@ from pydrake.systems.controllers import (
 class DoubleIntegrator(VectorSystem):
     def __init__(self):
         # One input, one output, two state variables.
-        VectorSystem.__init__(self, 1, 1)
+        VectorSystem.__init__(self, 1, 2)
         self.DeclareContinuousState(2)
 
     # qqdot(t) = u(t)

--- a/src/double_integrator/visualizer.py
+++ b/src/double_integrator/visualizer.py
@@ -1,0 +1,62 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from underactuated import PyPlotVisualizer
+from pydrake.systems.framework import (Context, PortDataType)
+
+
+_MIT_RED = '#A31F34'
+
+
+class Brick(object):
+
+    WIDTH = 5.
+    HEIGHT = 1.
+
+    def __init__(self):
+        self.patch = plt.Rectangle((0.0, 0.0),
+                                   self.WIDTH, self.HEIGHT,
+                                   fc=_MIT_RED, ec='k')
+        self.set_state(0.)
+
+    def set_state(self, x):
+        self.patch.set_x(x - self.WIDTH / 2)  # Center at x
+
+    @classmethod
+    def add_to_axes(cls, ax):
+        brick = cls()
+        ax.add_patch(brick.patch)
+        return brick
+
+
+class DoubleIntegratorVisualizer(PyPlotVisualizer):
+
+    # Limits of view port
+    XLIM = (-20., 20.)
+    YLIM = (-6., 6.)
+    TICK_DIMS = (0.2, 0.8)
+
+    def __init__(self):
+        PyPlotVisualizer.__init__(self)
+        self.DeclareInputPort(PortDataType.kVectorValued, 2)
+
+        self.ax.set_xlim(*self.XLIM)
+        self.ax.set_ylim(*self.YLIM)
+        self.ax.set_aspect('auto')
+
+        self._make_background()
+        self.brick = Brick.add_to_axes(self.ax)
+
+    def _make_background(self):
+        # x-axis
+        plt.plot(self.XLIM, np.zeros_like(self.XLIM), 'k')
+        # tick mark centered at the origin
+        tick_pos = -0.5 * np.asarray(self.TICK_DIMS)
+        self.ax.add_patch(plt.Rectangle(tick_pos, *self.TICK_DIMS, fc='k'))
+
+    def draw(self, context):
+        try:
+            x = self.EvalVectorInput(context, 0).get_value()[0]
+        except TypeError:
+            x = context[0]
+        self.brick.set_state(x)


### PR DESCRIPTION
Please take a look; fixes #209.

Note: I chose -20 < x < 20 for the X viewport: this is because the tolerance from the min-time cost function (0.05) makes the brick look off-center with lower limits. I chose the (q = -10, qdot = 0) starting conditions because they illustrate the "bang-bang" policy in this viewing region. (The policy seems to interpolate correctly even outside of the q in (-3, 3) range used for value iteration.)

Feel free to be nitpicky about code style; I didn't pay as much attention to surrounding code as I should have. Same for layout; I could easily move the DoubleIntegrator class into a double_integrator.py (with the DoubleIntegratorVisualizer); this resembles the structure in e.g. quadrotor2d.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/212)
<!-- Reviewable:end -->
