### PR TITLE
Scenegraph planar viz mesh + 3D scene support

### DIFF
--- a/scripts/setup/mac/install_prereqs
+++ b/scripts/setup/mac/install_prereqs
@@ -64,6 +64,7 @@ jupyter
 meshcat
 pycodestyle
 scipy
+shapely
 trimesh
 EOF
 )

--- a/scripts/setup/mac/install_prereqs
+++ b/scripts/setup/mac/install_prereqs
@@ -64,6 +64,7 @@ jupyter
 meshcat
 pycodestyle
 scipy
+trimesh
 EOF
 )
 

--- a/scripts/setup/ubuntu/16.04/install_prereqs
+++ b/scripts/setup/ubuntu/16.04/install_prereqs
@@ -60,6 +60,7 @@ jupyter
 meshcat
 pycodestyle
 tornado<6
+trimesh
 EOF
 )
 

--- a/scripts/setup/ubuntu/16.04/install_prereqs
+++ b/scripts/setup/ubuntu/16.04/install_prereqs
@@ -59,6 +59,7 @@ ipykernel==4.8.2
 jupyter
 meshcat
 pycodestyle
+shapely
 tornado<6
 trimesh
 EOF

--- a/scripts/setup/ubuntu/18.04/install_prereqs
+++ b/scripts/setup/ubuntu/18.04/install_prereqs
@@ -60,6 +60,7 @@ ipykernel==4.8.2
 jupyter
 meshcat
 pycodestyle
+shapely
 tornado<6
 trimesh
 EOF

--- a/scripts/setup/ubuntu/18.04/install_prereqs
+++ b/scripts/setup/ubuntu/18.04/install_prereqs
@@ -61,5 +61,6 @@ jupyter
 meshcat
 pycodestyle
 tornado<6
+trimesh
 EOF
 )

--- a/src/underactuated/CMakeLists.txt
+++ b/src/underactuated/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_pytest(planar_rigid_body_visualizer.py --torque 1.0 --duration 1.0 -a -m pend dpend)
 add_pytest(meshcat_rigid_body_visualizer.py --torque 1.0 --duration 1.0 --test -a -m pend dpend)
-add_pytest(planar_scenegraph_visualizer.py --duration 1.0)
+add_pytest(planar_scenegraph_visualizer.py --duration 1.0 -m pend manip)

--- a/src/underactuated/planar_scenegraph_visualizer.py
+++ b/src/underactuated/planar_scenegraph_visualizer.py
@@ -3,6 +3,11 @@
 import argparse
 import math
 import time
+# TODO(gizatt) logging.basicConfig() sets up basic logging handlers
+# that trimesh expects to be present, and allows trimesh errors
+# and warnings to make it to the console.
+import logging
+logging.basicConfig()  # noqa
 
 import numpy as np
 import matplotlib
@@ -235,8 +240,8 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                          for pt in sample_pts])
 
                 elif geom.type == geom.MESH:
-                    # TODO(gizatt): Remove trimesh dependency when vertex
-                    # information is accessible from the SceneGraph / Shape
+                    # TODO(gizatt): Remove trimesh and shapely dependency when
+                    # vertex information is accessible from the SceneGraph
                     # interface.
                     mesh = trimesh.load(geom.string_data)
                     patch = mesh.vertices.T


### PR DESCRIPTION
Putting this up to get some discussion started. Some preliminary testing on the single pendulum example test in `planar_scenegraph_visualizer.py` had total runtimes of [1.27s, 1.29s, 1.26s, 1.35s] with this change, and [1.28s, 1.26s, 1.26s, 1.26s] without it, weakly implying that for simple scenes, the extra overhead of projection and chull-ing in every iteration is negligible. For complex scenes, it's definitely not negligible, but I haven't done the A/B yet.

This also comes with a `trimesh` dependency for mesh loading. The version on pip has been reliable for me.

It'd keep things clean to replace the old planar viz with this strictly more complete one, but I'd be OK threading a `precompute_chulls` flag throughout (it'll be a little dirty). I guess we could split the visualizer into two versions, one with precomputed chulls and one without, but I think that'd be even more confusing.

Any preference? And is trimesh dependency OK?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/213)
<!-- Reviewable:end -->
