### PR TITLE
Give Xenial a specific networkx version

### DIFF
--- a/scripts/setup/ubuntu/16.04/install_prereqs
+++ b/scripts/setup/ubuntu/16.04/install_prereqs
@@ -58,6 +58,7 @@ ipython==5.8.0
 ipykernel==4.8.2
 jupyter
 meshcat
+networkx==2.2
 pycodestyle
 shapely
 tornado<6


### PR DESCRIPTION
This version _should_ be compatible with Python 2.7 up to Python 3.7, fixing the build server issue while maintaining compat for those who want to use it with Python 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/214)
<!-- Reviewable:end -->
