### PR TITLE
Point Xenial to Py2.7-compatible scipy

### DIFF
--- a/scripts/setup/ubuntu/16.04/install_prereqs
+++ b/scripts/setup/ubuntu/16.04/install_prereqs
@@ -60,6 +60,7 @@ jupyter
 meshcat
 networkx==2.2
 pycodestyle
+scipy==1.2.1
 shapely
 tornado<6
 trimesh


### PR DESCRIPTION
I was able to reproduce + fix the CI failure by launching the circlci docker image. Build + setup worked right with this change -- I didn't have the environment set up completely correctly so tests weren't passing, but this should hopefully get it the rest of the way?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/215)
<!-- Reviewable:end -->
