### PR TITLE
Fixes issue https://github.com/RussTedrake/underactuated/issues/268 and adds ID to wheeled robot example in Chap.1

### DIFF
--- a/underactuated.html
+++ b/underactuated.html
@@ -668,7 +668,7 @@ are available on YouTube</a>.</p>
       freedom of a system by one, a nonholonomic constraint does not.  An
       automobile or traditional wheeled robot provides a canonical example:</p>
 
-      <example><h1>Wheeled robot</h1> Consider a simple model of
+      <example id="wheeled_robot"><h1>Wheeled robot</h1> Consider a simple model of
       a wheeled robot whose configuration is described by its Cartesian position
       $x,y$ and its orientation, $\theta$, so $\bq = \begin{bmatrix} x, y,
       \theta \end{bmatrix}^T$.  The system is subject to a differential

--- a/underactuated/BUILD.bazel
+++ b/underactuated/BUILD.bazel
@@ -21,5 +21,5 @@ rt_py_library(
         "utils.py",
     ],
     imports = [".."],
-    visibility = [":__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
In the PR https://github.com/RussTedrake/underactuated/pull/270: I linked the control-Lyapunov exercise to the wheeled robot example, but I forgot to give a html id to the example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/274)
<!-- Reviewable:end -->
