### PR TITLE
Adds the BUILD.bazel to the exercise notebooks

### DIFF
--- a/exercises/lyapunov/control/BUILD.bazel
+++ b/exercises/lyapunov/control/BUILD.bazel
@@ -9,6 +9,5 @@ load("//tools/rt/jupyter:defs.bzl", "rt_ipynb_test")
 rt_ipynb_test(
     name = "control",
     srcs = ["control.ipynb"],
-    size = "medium",
     deps = ["//underactuated"],
 )

--- a/exercises/lyapunov/control/BUILD.bazel
+++ b/exercises/lyapunov/control/BUILD.bazel
@@ -1,0 +1,14 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+# Copyright 2020 Massachusetts Institute of Technology.
+# Licensed under the BSD 3-Clause License. See LICENSE.TXT for details.
+
+load("//tools/rt/jupyter:defs.bzl", "rt_ipynb_test")
+
+rt_ipynb_test(
+    name = "control",
+    srcs = ["control.ipynb"],
+    size = "medium",
+    deps = ["//underactuated"],
+)

--- a/exercises/pend/attractivity_vs_stability/BUILD.bazel
+++ b/exercises/pend/attractivity_vs_stability/BUILD.bazel
@@ -9,6 +9,5 @@ load("//tools/rt/jupyter:defs.bzl", "rt_ipynb_test")
 rt_ipynb_test(
     name = "attractivity_vs_stability",
     srcs = ["attractivity_vs_stability.ipynb"],
-    size = "medium",
     deps = ["//underactuated"],
 )

--- a/exercises/pend/attractivity_vs_stability/BUILD.bazel
+++ b/exercises/pend/attractivity_vs_stability/BUILD.bazel
@@ -1,0 +1,14 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+# Copyright 2020 Massachusetts Institute of Technology.
+# Licensed under the BSD 3-Clause License. See LICENSE.TXT for details.
+
+load("//tools/rt/jupyter:defs.bzl", "rt_ipynb_test")
+
+rt_ipynb_test(
+    name = "attractivity_vs_stability",
+    srcs = ["attractivity_vs_stability.ipynb"],
+    size = "medium",
+    deps = ["//underactuated"],
+)

--- a/exercises/pend/vibrating_pendulum/BUILD.bazel
+++ b/exercises/pend/vibrating_pendulum/BUILD.bazel
@@ -9,7 +9,6 @@ load("//tools/rt/jupyter:defs.bzl", "rt_ipynb_test")
 rt_ipynb_test(
     name = "vibrating_pendulum",
     srcs = ["vibrating_pendulum.ipynb"],
-    size = "medium",
     data = ["//underactuated/models:vibrating_pendulum.urdf"],
     deps = ["//underactuated"],
 )

--- a/exercises/pend/vibrating_pendulum/BUILD.bazel
+++ b/exercises/pend/vibrating_pendulum/BUILD.bazel
@@ -1,0 +1,15 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+# Copyright 2020 Massachusetts Institute of Technology.
+# Licensed under the BSD 3-Clause License. See LICENSE.TXT for details.
+
+load("//tools/rt/jupyter:defs.bzl", "rt_ipynb_test")
+
+rt_ipynb_test(
+    name = "vibrating_pendulum",
+    srcs = ["vibrating_pendulum.ipynb"],
+    size = "medium",
+    data = ["//underactuated/models:vibrating_pendulum.urdf"],
+    deps = ["//underactuated"],
+)


### PR DESCRIPTION
So far all the exercise notebooks can be run without the solution cell plugged in. I added a `BUILD.bazel` next to each exercise notebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/284)
<!-- Reviewable:end -->
