### PR TITLE
Avoids the use of the words "phase portrait" in the intro. Replaces #286.

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -695,11 +695,11 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
         <li> For any twice-differentiable desired trajectory $\bq_{\text{des}}(t)$, is it always possible to find a control signal $\bu(t)$ such that $\bq(t) = \bq_{\text{des}}(t)$ for all $t \geq 0$, provided that $\bq(0) = \bq_{\text{des}}(0)$ and $\dot \bq(0) = \dot \bq_{\text{des}}(0)$?</li>
 
-        <li>Now consider the simplest fully-actuated robot: the double integrator. The dynamics of this system reads $m \ddot q = u$, and you can think of it as a cart of mass $m$ moving on a straight rail, controlled by a force $u$.  The figure below depicts its vector field (i.e., the vector $\dot \bx = [\dot q, u/m]^T$ for different values of $\bx=[q, \dot q]^T$) when $u=0$.  Is it possible to find a control signal $u(t)$ that drives the double integrator from the initial state $\bx(0) = [2, 0.5]^T$ to the origin along a straight line (blue trajectory)? Does the answer change if we set $\bx(0)$ to be $[2, -0.5]^T$ (red trajectory)?
+        <li>Now consider the simplest fully-actuated robot: the double integrator. The dynamics of this system reads $m \ddot q = u$, and you can think of it as a cart of mass $m$ moving on a straight rail, controlled by a force $u$.  The figure below depicts its <a href="pend.html#pend_zero_torque">phase portrait</a> when $u=0$.  Is it possible to find a control signal $u(t)$ that drives the double integrator from the initial state $\bx(0) = [2, 0.5]^T$ to the origin along a straight line (blue trajectory)? Does the answer change if we set $\bx(0)$ to be $[2, -0.5]^T$ (red trajectory)?
 
         <figure>
           <img width="60%" src="figures/exercises/trajectory_tracking.svg"/>
-          <figcaption>Vector field of the double integrator.</figcaption>
+          <figcaption>Phase portrait of the double integrator.</figcaption>
         </figure>
 
         <li> The dynamics \ref{eq:f1_plus_f2} are $n=\dim[\bq]$ <i>second-order</i> differential equations.  However, it is always possible (and we'll frequently do it) to describe these equations in terms of $2n$ <i>first-order</i> differential equations $\dot \bx = f(\bx,t)$.  To this end, we simply define $$f(\bx,t) = \begin{bmatrix} \dot\bq \\ {\bf f}_1(\bq,\dot\bq,t) + {\bf f}_2(\bq,\dot\bq,t)\bu \end{bmatrix}.$$  For any twice-differentiable trajectory $\bx_{\text{des}}(t)$, is it always possible to find a control $\bu(t)$ such that $\bx(t) = \bx_{\text{des}}(t)$ for all $t \geq 0$, provided that $\bx(0) = \bx_{\text{des}}(0)$?</li>

--- a/intro.html
+++ b/intro.html
@@ -697,11 +697,10 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
         <li>Now consider the simplest fully-actuated robot: the double integrator. The dynamics of this system reads $m \ddot q = u$, and you can think of it as a cart of mass $m$ moving on a straight rail, controlled by a force $u$.  The figure below depicts its vector field (i.e., the vector $\dot \bx = [\dot q, u/m]^T$ for different values of $\bx=[q, \dot q]^T$) when $u=0$.  Is it possible to find a control signal $u(t)$ that drives the double integrator from the initial state $\bx(0) = [2, 0.5]^T$ to the origin along a straight line (blue trajectory)? Does the answer change if we set $\bx(0)$ to be $[2, -0.5]^T$ (red trajectory)?
 
-
-          <figure>
-            <img width="60%" src="figures/exercises/trajectory_tracking.svg"/>
-            <figcaption>Vector field of the double integrator.</figcaption>
-          </figure>
+        <figure>
+          <img width="60%" src="figures/exercises/trajectory_tracking.svg"/>
+          <figcaption>Vector field of the double integrator.</figcaption>
+        </figure>
 
         <li> The dynamics \ref{eq:f1_plus_f2} are $n=\dim[\bq]$ <i>second-order</i> differential equations.  However, it is always possible (and we'll frequently do it) to describe these equations in terms of $2n$ <i>first-order</i> differential equations $\dot \bx = f(\bx,t)$.  To this end, we simply define $$f(\bx,t) = \begin{bmatrix} \dot\bq \\ {\bf f}_1(\bq,\dot\bq,t) + {\bf f}_2(\bq,\dot\bq,t)\bu \end{bmatrix}.$$  For any twice-differentiable trajectory $\bx_{\text{des}}(t)$, is it always possible to find a control $\bu(t)$ such that $\bx(t) = \bx_{\text{des}}(t)$ for all $t \geq 0$, provided that $\bx(0) = \bx_{\text{des}}(0)$?</li>
 

--- a/intro.html
+++ b/intro.html
@@ -695,11 +695,12 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
         <li> For any twice-differentiable desired trajectory $\bq_{\text{des}}(t)$, is it always possible to find a control signal $\bu(t)$ such that $\bq(t) = \bq_{\text{des}}(t)$ for all $t \geq 0$, provided that $\bq(0) = \bq_{\text{des}}(0)$ and $\dot \bq(0) = \dot \bq_{\text{des}}(0)$?</li>
 
-        <li>Now consider the simplest fully-actuated robot: the double integrator. The dynamics of this system reads $m \ddot q = u$, and you can think of it as a cart of mass $m$ moving on a straight rail, controlled by a force $u$.  The figure below depicts its phase portrait for $u=0$.  Is it possible to find a control signal $u(t)$ that drives the double integrator from the initial state $\bx(0) = [2, 0.5]^T$ to the origin along a straight line (blue trajectory)? Does the answer change if we set $\bx(0)$ to be $[2, -0.5]^T$ (red trajectory)?
+        <li>Now consider the simplest fully-actuated robot: the double integrator. The dynamics of this system reads $m \ddot q = u$, and you can think of it as a cart of mass $m$ moving on a straight rail, controlled by a force $u$.  The figure below depicts its vector field (i.e., the vector $\dot \bx = [\dot q, u/m]^T$ for different values of $\bx=[q, \dot q]^T$) when $u=0$.  Is it possible to find a control signal $u(t)$ that drives the double integrator from the initial state $\bx(0) = [2, 0.5]^T$ to the origin along a straight line (blue trajectory)? Does the answer change if we set $\bx(0)$ to be $[2, -0.5]^T$ (red trajectory)?
+
 
           <figure>
             <img width="60%" src="figures/exercises/trajectory_tracking.svg"/>
-            <figcaption>Phase portrait of the double integrator.</figcaption>
+            <figcaption>Vector field of the double integrator.</figcaption>
           </figure>
 
         <li> The dynamics \ref{eq:f1_plus_f2} are $n=\dim[\bq]$ <i>second-order</i> differential equations.  However, it is always possible (and we'll frequently do it) to describe these equations in terms of $2n$ <i>first-order</i> differential equations $\dot \bx = f(\bx,t)$.  To this end, we simply define $$f(\bx,t) = \begin{bmatrix} \dot\bq \\ {\bf f}_1(\bq,\dot\bq,t) + {\bf f}_2(\bq,\dot\bq,t)\bu \end{bmatrix}.$$  For any twice-differentiable trajectory $\bx_{\text{des}}(t)$, is it always possible to find a control $\bu(t)$ such that $\bx(t) = \bx_{\text{des}}(t)$ for all $t \geq 0$, provided that $\bx(0) = \bx_{\text{des}}(0)$?</li>

--- a/pend.html
+++ b/pend.html
@@ -294,7 +294,7 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
     </subsection> <!-- end of overdamped pend -->
 
-    <subsection><h1>The undamped pendulum with zero torque</h1>
+    <subsection id="pend_zero_torque"><h1>The undamped pendulum with zero torque</h1>
 
       <p> Consider again the system $$ml^2 \ddot\theta = u_0 - mgl \sin\theta -
       b\dot\theta,$$ this time with $b = 0$.  This time the system dynamics are


### PR DESCRIPTION
Replaces #286.

Just realized that, after the modification we discussed, this exercise might feel more natural if moved to Chapter 2? It requires to think how control can modify the vector field of a second order system (similar to the case of the pendulum we discussed after class today).

For the moment I just modified it to avoid the term "phase portrait", since it is defined in Chap. 2. This is part of this week's pset, so I wouldn't move it to Chap. 2 before Feb. 13. But if you think this modification makes students' life easier for this week's pset, please merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/293)
<!-- Reviewable:end -->
