### PR TITLE
Fixes the link to the nb in the carpole exercise.

### DIFF
--- a/acrobot.html
+++ b/acrobot.html
@@ -1207,7 +1207,7 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
     <exercise><h1>Cart-Pole: Linearization and Balancing</h1>
 
-      <p>For this exercise you will work exclusively in <a href="https://colab.research.google.com/github/RussTedrake/underactuated/blob/master/exercises/acrobot/cartpole_lin_bal/cartpole_lin_bal.ipynb" target="_blank">this notebook</a>.  You will be asked to complete the following steps.</p>
+      <p>For this exercise you will work exclusively in <a href="https://colab.research.google.com/github/RussTedrake/underactuated/blob/master/exercises/acrobot/cartpole_balancing/cartpole_balancing.ipynb" target="_blank">this notebook</a>.  You will be asked to complete the following steps.</p>
 
       <ol type="a">
 


### PR DESCRIPTION
I forgot to update from `lin_bal` to `balancing` the link to the colab notebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/306)
<!-- Reviewable:end -->
