### PR TITLE
Cleans up the lyapunov questions before publishing the pset.

### DIFF
--- a/lyapunov.html
+++ b/lyapunov.html
@@ -965,45 +965,31 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
   <section><h1>Exercises</h1>
 
-    <exercise><h1>Lyapunov Stability</h1>
+    <exercise><h1>Valid Lyapunov Function for Global Stability</h1>
 
-      <p>A dynamical system is defined by the equations $\dot{x_1}=f_1(x_1,x_2)$
-        and $\dot{x_2}=f_2(x_1,x_2)$. You find that the function $V=\frac{1}{2}x_1^2$ 
-        has a derivative $\dot{V} = \left[\dfrac{dV}{dx_1}, \dfrac{dV}{dx_2}\right] 
-        \left[ f_1, f_2 \right]^T$ which is negative semidefinite. 
-        Can you infer global stability of the origin? Can you infer stability 
-        for $x_1$ and $x_2$ individually?</p>
+      <p>For the system \begin{align*} \dot x_1 &=-\frac{6x_1}{(1+x_1^2)^2}+2x_2, \\
+         \dot x_2 &=-\frac{2(x_1+x_2)}{(1+x_1^2)^2}.\end{align*}
+        you are given the positive definite function $V(\bx) =\frac{x_1^2}{1 + x_1^2}+ 
+        x_2^2$ and told that, for this system, $\dot V(\bx)$ is negative definite over 
+        the entire space. Is $V(\bx)$ a valid Lyapunov function to prove global 
+        asymptotic stability of the origin for the system described by the 
+        equations above? Motivate your answer.</p>
       
     </exercise>
 
-    <exercise><h1>Valid Lyapunov Function</h1>
+    <exercise><h1>Invariant Sets and Regions of Attraction</h1>
 
-      <p>For the system
-        $$\begin{align} \dot{x_1}&amp;=-\frac{6x_1}{(1+x_1^2)^2}+2x_2 \\
-         \dot{x_2}&amp;=-\frac{2(x_1+x_2)}{(1+x_1^2)^2} \end{align}$$
-        you are given the positive definite function $V(x) =\frac{x_1^2}{1 + x_1^2}+ 
-        x_2^2$ and told that, for this system, $\dot{V}$ is negative definite over 
-        the entire space. Is $V$ a valid Lyapunov function which proves global 
-        asymptotic stability to the origin for the system described by these 
-        equations? Why or why not? Hint: Try simulating a few trajectories of 
-        this system or plotting the vector field to build more intuition 
-        before answering this problem.</p>
-      
-    </exercise>
-
-    <exercise><h1>Lyapunov Analysis</h1>
-
-      <p>Given dynamics $\dot{x} = f(x)$ and a Lyapunov candidate $V(x)$, 
-        let $D$ be any domain such that for all $\hat{x} \in D$, $V(\hat{x})$ 
-        is positive definite and $\dot{V}(\hat{x})$ is negative definite.</p>
+      <p>Given the dynamics $\dot \bx = f(\bx)$ and a Lyapunov candidate function $V(\bx)$, 
+        let $D$ be a set (with the origin in its interior) such that, for all $\bx \in D$, $V(\bx)$ 
+        is positive definite and $\dot V (\bx)$ is negative definite.</p>
 
       <ol type="a">
 
-        <li>Can we say that all initial conditions inside $D$ will stay inside $D$?
-           Why or why not?</li>
+        <li>Can we say that, for all initial conditions inside $D$, the system's state will always stay inside $D$?
+           Motivate your answer.</li>
         
-        <li>Can we say that all initial conditions inside $D$ will converge 
-          to the origin? Why or why not?</li>
+        <li>Can we say that for all initial conditions inside $D$ the system's state will converge 
+          to the origin? Motivate your answer.</li>
 
       </ol>
 
@@ -1011,18 +997,16 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
     <exercise><h1>Are Lyapunov Functions Unique?</h1>
 
-      <p>If $V_1(x)$ and $V_2(x)$ are valid Lyapunov functions that prove global 
-        stability of a system to the origin, does $V_1(x)$ necessarily equal 
-        $V_2(x)$? In other words, are Lyapunov functions unique? Why or why not?</p>
+      <p>If $V_1(\bx)$ and $V_2(\bx)$ are valid Lyapunov functions that prove global asymptotic
+        stability of the origin, does $V_1(\bx)$ necessarily equal 
+        $V_2(\bx)$?</p>
 
     </exercise>
 
-    <exercise><h1>Global Asymptotic Stability</h1>
+    <exercise><h1>Proving Global Asymptotic Stability</h1>
 
-      <p>Consider the system given by $$ \dot{x}= \left(\begin{array}{c} {x_2} - 
-        {{x_1}}^3\ - {{x_2}}^3 - {x_1} \end{array}\right)\label{p2System} $$
-         Show that the Lyapunov function $$ V(x) = x_1^2 + x_2^2 $$        
-        proves global asymptotic stability of the above equation to the origin.</p>
+      <p>Consider the system given by \begin{align*} \dot x_1 &= x_2 - x_1^3, \\ \dot x_2 &= - x_1 - x_2^3. \end{align*}
+      Show that the Lyapunov function $V(\bx) = x_1^2 + x_2^2$ proves global asymptotic stability of the origin for this system.</p>
 
     </exercise>
 
@@ -1053,47 +1037,14 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
     </exercise>
 
-    <exercise><h1>Sums of Squares (SOS) for Lyapunov functions &mdash; Quick check
-       for understanding</h1>
+    <exercise><h1>Limitations of SOS Polynomials in Lyapunov Analysis</h1>
 
-      <p>We recommend you stop for a second to make sure you can answer the
-         following questions:</p>
-      
       <ol type="a">
 
-        <li>What is the simplest example of a function that is a sum of squares?</li>
-        
-        <li>What is arguably the most useful property of functions that are sums 
-          of squares? When are they positive? When are they negative?</li>
+        <li>Are there positive definite functions that are not representable as sums of squares?</li>
 
-        <li>Are there functions that also have this property, but do not belong
-           to the set of sums of squares? (Hint: Google the Motzkin polynomial mentioned in class.)</li>
+        <li>If a fixed point of our dynamical system does not admit a SOS Lyapunov function, what can we conclude about its stability?</li>
 
-        <li>How do sums of squares (SOS) relate to Lyapunov functions?</li>
-
-        <li>Specifically, which property (or properties) of Lyapunov
-           functions do we relate to them being sums of squares or not?</li>
-
-        <li>To make an expressive set of functions over our state space, 
-          we choose some set of monomials $m(x)$. What are some examples 
-          of good choices for $m(x)$?</li>
-
-        <li>What does the form $V(x) = m^T(x) Q m^T(x)$ have to do with 
-          a function being sums of squares?</li>
-
-        <li>Searching for $Q$ in the above question can be formulated as 
-          a Semidefinite Program. What is the difference between Quadratic 
-          Programming and Semidefinite Programming?</li>
-
-        <li>If we find, using SOS optimization, a valid Lyapunov 
-          function, then what does this say about our system?</li>
-
-        <li>If we cannot find, using SOS optimization, a valid 
-          Lyapunov function, then what does this say about our system?</li>
-
-        <li>We are using SOS to help find Lyapunov functions. 
-          How does this help our robots?</li>
-      
       </ol>
 
     </exercise>


### PR DESCRIPTION
We found some typos and minor things to fix in the written exercises for pset 3, they are fixed here.

We also removed the fist question (since it was a little misleading) and we reduced the "quick understanding" on SOS to the two most relevant questions.

For the rest, it is just formatting and aligning the notation with the text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/322)
<!-- Reviewable:end -->
