### PR TITLE
Fixes a typo in Van der Pol notebook

### DIFF
--- a/exercises/lyapunov/van_der_pol/van_der_pol.ipynb
+++ b/exercises/lyapunov/van_der_pol/van_der_pol.ipynb
@@ -70,7 +70,7 @@
     "The equations of motion for this system are polynomial, and read as follows:\n",
     "\\begin{align}\n",
     "\\dot x_1 &= - x_2, \\\\\n",
-    "\\dot x_2 &= x_1 + (x_2^2 - 1) x_2.\n",
+    "\\dot x_2 &= x_1 + (x_1^2 - 1) x_2.\n",
     "\\end{align}\n",
     "We compactly represent the latter as $\\dot{\\mathbf{x}} = f(\\mathbf{x})$, with $\\mathbf{x} = [x_1, x_2]^T$."
    ]


### PR DESCRIPTION
A student pointed out this typo in the text description of the Van der Pol dynamics in the notebook. Corrected here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/328)
<!-- Reviewable:end -->
