### PR TITLE
Fixes the equation display in example 2.3

### DIFF
--- a/pend.html
+++ b/pend.html
@@ -452,8 +452,8 @@ complete trajectory.</p>
 
     <example><h1>Unstable equilibrium point that attracts all trajectories</h1>
 
-      <p>Consider the system \[ \dot{r} = r(1-r) \\ \dot\theta = \sin^2
-      (\frac{\theta}{2}). \]  This system has two equilibrium points, one at
+      <p>Consider the system \begin{align*} \dot{r} &= r(1-r), \\ \dot\theta &= \sin^2
+      \left( \frac{\theta}{2} \right).\end{align*}  This system has two equilibrium points, one at
       $r^*=0,\theta^*=0$, and the other at $r^* = 1,\theta^*=0$.  The fixed
       point at zero is clearly unstable.  The fixed point with $r^*=1$ attracts
       all other trajectories, but it is not stable by any of our


### PR DESCRIPTION
In the current version, the equation for theta does not go to the next line.
Also adapts the size of the parenthesis to the frac argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/331)
<!-- Reviewable:end -->
