### PR TITLE
Gradescope fix hw4

### DIFF
--- a/underactuated/exercises/grader.py
+++ b/underactuated/exercises/grader.py
@@ -52,9 +52,9 @@ class Grader:
     def locals_from_notebook(notebook_ipynb):
         """Read, run, return locals of notebook"""
         banned_commands = [
-            'start_recording',
-            'stop_recording',
-            'get_recording_as_animation',
+            # 'start_recording',
+            # 'stop_recording',
+            # 'get_recording_as_animation',
             'HTML',
         ]
 

--- a/underactuated/exercises/grader.py
+++ b/underactuated/exercises/grader.py
@@ -51,12 +51,7 @@ class Grader:
     @staticmethod
     def locals_from_notebook(notebook_ipynb):
         """Read, run, return locals of notebook"""
-        banned_commands = [
-            # 'start_recording',
-            # 'stop_recording',
-            # 'get_recording_as_animation',
-            'HTML',
-        ]
+        banned_commands = ['HTML']
 
         ipynb = json.load(open(notebook_ipynb))
 

--- a/underactuated/exercises/trajopt/shooting_vs_transcription/test_shooting_vs_transcription.py
+++ b/underactuated/exercises/trajopt/shooting_vs_transcription/test_shooting_vs_transcription.py
@@ -47,6 +47,7 @@ class TestShootingVsTranscription(unittest.TestCase):
         for i, bits in enumerate(lost_bits):
             self.assertAlmostEqual(bits,
                                    lost_bits_shooting[i],
+                                   places=3,
                                    msg='lost_bits_shooting are incorrect.')
 
     @weight(4)

--- a/underactuated/exercises/trajopt/shooting_vs_transcription/test_shooting_vs_transcription.py
+++ b/underactuated/exercises/trajopt/shooting_vs_transcription/test_shooting_vs_transcription.py
@@ -47,7 +47,7 @@ class TestShootingVsTranscription(unittest.TestCase):
         for i, bits in enumerate(lost_bits):
             self.assertAlmostEqual(bits,
                                    lost_bits_shooting[i],
-                                   places=3,
+                                   places=2,
                                    msg='lost_bits_shooting are incorrect.')
 
     @weight(4)

--- a/underactuated/exercises/trajopt/shooting_vs_transcription/test_shooting_vs_transcription.py
+++ b/underactuated/exercises/trajopt/shooting_vs_transcription/test_shooting_vs_transcription.py
@@ -47,7 +47,7 @@ class TestShootingVsTranscription(unittest.TestCase):
         for i, bits in enumerate(lost_bits):
             self.assertAlmostEqual(bits,
                                    lost_bits_shooting[i],
-                                   places=2,
+                                   places=1,
                                    msg='lost_bits_shooting are incorrect.')
 
     @weight(4)


### PR DESCRIPTION
These are minor changes to make the autograding on gradescope work reliably. 

1) Stop removing cells with certain content as it was interfering.
2) Reduce accuracy in the test for shooting_vs_transcriptions.

No rush for this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/347)
<!-- Reviewable:end -->
