### PR TITLE
Fixes a comment and sign of radii in the orbital transfer notebook

### DIFF
--- a/exercises/trajopt/orbital_transfer/orbital_transfer.ipynb
+++ b/exercises/trajopt/orbital_transfer/orbital_transfer.ipynb
@@ -672,7 +672,7 @@
     "# modify here\n",
     "\n",
     "# minimize fuel consumption, for all t:\n",
-    "# add to the objective the two norm of the thrust\n",
+    "# add to the objective the two norm suqared of the thrust\n",
     "# multiplied by the time_interval so that the optimal cost\n",
     "# approximates the time integral of the thrust squared\n",
     "\n",

--- a/exercises/trajopt/orbital_transfer/orbital_transfer.ipynb
+++ b/exercises/trajopt/orbital_transfer/orbital_transfer.ipynb
@@ -672,7 +672,7 @@
     "# modify here\n",
     "\n",
     "# minimize fuel consumption, for all t:\n",
-    "# add to the objective the two norm suqared of the thrust\n",
+    "# add to the objective the two norm squared of the thrust\n",
     "# multiplied by the time_interval so that the optimal cost\n",
     "# approximates the time integral of the thrust squared\n",
     "\n",

--- a/exercises/trajopt/orbital_transfer/orbital_transfer.ipynb
+++ b/exercises/trajopt/orbital_transfer/orbital_transfer.ipynb
@@ -209,7 +209,7 @@
     "    'red',       # color for plot\n",
     "    6.417e23,    # mass in kg\n",
     "    np.zeros(2), # Mars is chosen as the origin of our 2D universe\n",
-    "    1.5e10,        # orbit radius in m\n",
+    "    1.5e10,      # orbit radius in m\n",
     "    3.389e6,     # radius in m\n",
     ")\n",
     "\n",
@@ -224,7 +224,7 @@
     "            'brown',                                   # color for plot\n",
     "            np.random.randn() * 5e22,                  # mass in kg\n",
     "            np.random.randn(2) * 5e10 + [1e11, -1e10], # distance wrt Mars in m\n",
-    "            np.random.randn() * 1e10,                  # radius danger area in m\n",
+    "            np.abs(np.random.randn()) * 1e10,          # radius danger area in m\n",
     "        )\n",
     "    )"
    ]


### PR DESCRIPTION
One student noticed that I forgot in one point to specify that the objective function should be the 2-norm **squared** of the thrust. Fixed in this PR.

**Edit:** There was also a gross mistake: in the construction of the asteroids, I was sampling all the parameters using `randn`, included masses and radii (which were then allowed to be negative).

**Temporary Fix:** Actually, I was always using the radii squared so I just modified the code to use `abs(randn)` for the radii, and nothing changed. But doing the same for the masses leads to some issues with the auto grading (cannot achieve the required fuel consumption). Since I want to minimize the modifications while the pset is out, I'd leave some of the asteroids have negative mass. This implies nonphysical repulsion of the rocket from some planets but does not break the code.

Russ: I hope you agree with this choice. I'll open an issue and fix it after the pset deadline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/349)
<!-- Reviewable:end -->
