### PR TITLE
Fix footstep planner tests

### DIFF
--- a/underactuated/exercises/humanoids/footstep_planning/test_footstep_planning.py
+++ b/underactuated/exercises/humanoids/footstep_planning/test_footstep_planning.py
@@ -123,9 +123,18 @@ class TestFootstepPlanning(unittest.TestCase):
         # check constraint for both terrains
         target_cost = {'A': 4.1592510194, 'B': 5.6478552756}
         for plan in ['A', 'B']:
-            self.assertAlmostEqual(
-                self.plans[plan]['cost'],
-                target_cost[plan],
-                places=2,
-                msg=f'Target cost of {target_cost[plan]} is not achieved for ' +
-                f'terrain_{plan}.')
+
+            # same convergence check as in
+            # https://github.com/RobotLocomotion/drake/blob/88c93118df507777eb3f99628d1aa7c808f81f49/solvers/branch_and_bound.cc#L711
+            # with the tolerances from
+            # https://github.com/RobotLocomotion/drake/blob/4ee674e7931527df838bd33e79cf2f4dad57bd20/solvers/branch_and_bound.h#L674
+            atol = 1e-2
+            rtol = 1e-2
+            gap = self.plans[plan]['cost'] - target_cost[plan]
+            atol_convergence = gap <= atol
+            rtol_convergence = gap / target_cost[plan] <= rtol
+            self.assertTrue(
+                atol_convergence or rtol_convergence,
+                f'Target cost of {target_cost[plan]} is not achieved for ' +
+                f'terrain_{plan}, with absolute tolerance {atol} and ' +
+                f'relative tolerance {rtol}')

--- a/underactuated/exercises/humanoids/footstep_planning/test_footstep_planning.py
+++ b/underactuated/exercises/humanoids/footstep_planning/test_footstep_planning.py
@@ -126,9 +126,9 @@ class TestFootstepPlanning(unittest.TestCase):
 
             # same convergence check as in
             # https://github.com/RobotLocomotion/drake/blob/88c93118df507777eb3f99628d1aa7c808f81f49/solvers/branch_and_bound.cc#L711
-            # with the tolerances from
+            # with double the tolerances from
             # https://github.com/RobotLocomotion/drake/blob/4ee674e7931527df838bd33e79cf2f4dad57bd20/solvers/branch_and_bound.h#L674
-            atol = 2e-2  # double the tolerances from the C++ code
+            atol = 2e-2
             rtol = 2e-2
             gap = self.plans[plan]['cost'] - target_cost[plan]
             atol_convergence = gap <= atol
@@ -137,4 +137,4 @@ class TestFootstepPlanning(unittest.TestCase):
                 atol_convergence or rtol_convergence,
                 f'Target cost of {target_cost[plan]} is not achieved for ' +
                 f'terrain_{plan}, with absolute tolerance {atol} and ' +
-                f'relative tolerance {rtol}')
+                f'relative tolerance {rtol}.')

--- a/underactuated/exercises/humanoids/footstep_planning/test_footstep_planning.py
+++ b/underactuated/exercises/humanoids/footstep_planning/test_footstep_planning.py
@@ -128,8 +128,8 @@ class TestFootstepPlanning(unittest.TestCase):
             # https://github.com/RobotLocomotion/drake/blob/88c93118df507777eb3f99628d1aa7c808f81f49/solvers/branch_and_bound.cc#L711
             # with the tolerances from
             # https://github.com/RobotLocomotion/drake/blob/4ee674e7931527df838bd33e79cf2f4dad57bd20/solvers/branch_and_bound.h#L674
-            atol = 1e-2
-            rtol = 1e-2
+            atol = 2e-2  # double the tolerances from the C++ code
+            rtol = 2e-2
             gap = self.plans[plan]['cost'] - target_cost[plan]
             atol_convergence = gap <= atol
             rtol_convergence = gap / target_cost[plan] <= rtol


### PR DESCRIPTION
There was a typo in the check of the optimal cost: the tolerance was defined but not used. Fixed here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/365)
<!-- Reviewable:end -->
