### PR TITLE
fixed title name of the hopfield_network.ipynb

### DIFF
--- a/exercises/pend/hopfield_network/hopfield_network.ipynb
+++ b/exercises/pend/hopfield_network/hopfield_network.ipynb
@@ -7,7 +7,7 @@
    "lastKernelId": null
   },
   "colab": {
-   "name": "hopfield_network_with_pokemon.ipynb",
+   "name": "hopfield_network.ipynb",
    "provenance": [],
    "collapsed_sections": []
   },


### PR DESCRIPTION
to match the name that Gradescope is expecting when downloaded from Colab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/413)
<!-- Reviewable:end -->
