### PR TITLE
Update fitted_double_integrator.ipynb

### DIFF
--- a/exercises/dp/fitted_double_integrator/fitted_double_integrator.ipynb
+++ b/exercises/dp/fitted_double_integrator/fitted_double_integrator.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "And we have the minimum time cost:\n",
     "\n",
-    "$$g(x) = 1 \\text{  if  } x = 0, \\text{  else  } 0$$\n",
+    "$$g(x) = 1 \\text{  if  } x \\neq 0, \\text{  else  } 0$$\n",
     "\n",
     "These will both seek to stabilize the system to the origin $x = 0$. The solution to the quadratic regulator cost makes use of drake to generate to solve the algebraic riccati equation and generate the solution matrix $S$.\n"
    ]


### PR DESCRIPTION
to fix cost function

Fixes the typo in the minimum cost function in the fitted_double_integrator.ipynb
Currently, it states that the cost is 1 when at the goal and zero otherwise when it should be the other way around

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/430)
<!-- Reviewable:end -->
