### PR TITLE
Fix an index typo in REINFORCE algorithm

### DIFF
--- a/rl_policy_search.html
+++ b/rl_policy_search.html
@@ -150,10 +150,10 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture videos a
       p_\alpha(\bu[n] | \bx[n]).$$  Only the last terms depend on $\alpha$,
       which yields \begin{align*} \frac{\partial}{\partial \alpha} E \left[
       \sum_{n=0}^N \ell(\bx[n], \bu[n]) \right] &= E\left[ \left( \sum_{n=0}^N
-      \ell(\bx[n],\bu[n]) \right) \left(\sum_{n=0}^N \frac{\partial}{\partial
-      \alpha} \log p_\alpha(\bu[n]|\bx[n]) \right) \right] \\ &= E\left[
+      \ell(\bx[n],\bu[n]) \right) \left(\sum_{k=0}^N \frac{\partial}{\partial
+      \alpha} \log p_\alpha(\bu[k]|\bx[k]) \right) \right] \\ &= E\left[
       \sum_{n=0}^N \left( \ell(\bx[n],\bu[n]) \sum_{k=0}^n
-      \frac{\partial}{\partial \alpha} \log p_\alpha(\bu[n]|\bx[n]) \right)
+      \frac{\partial}{\partial \alpha} \log p_\alpha(\bu[k]|\bx[k]) \right)
       \right], \end{align*} where the last step uses the fact that
       $E\left[\ell(\bx[n],\bu[n])\frac{\partial}{\partial \alpha} \log
       p_\alpha(\bu[k]|\bx[k]) \right] = 0$ for all $k > n$.</p>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/450)
<!-- Reviewable:end -->
