### PR TITLE
Increase size of conditional expectation bars

### DIFF
--- a/rl_policy_search.html
+++ b/rl_policy_search.html
@@ -145,20 +145,20 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture videos a
       \frac{\partial}{\partial \alpha} \log p_\alpha(\bx[\cdot],\bu[\cdot])
       \right], \end{align*} where $\bx[\cdot]$ is shorthand for the entire
       trajectory $\bx[0], ..., \bx[n]$, and $$ p_\alpha(\bx[\cdot],\bu[\cdot]) =
-      p_0(\bx[0]) \left(\prod_{n=1}^N p(\bx[n] | \bx[n-1],\bu[n-1]) \right)
-      \left(\prod_{n=0}^N p_\alpha(\bu[n] | \bx[n]) \right).$$ Taking the $\log$
-      we have $$\log p_\alpha(\bx[\cdot],\bu[\cdot]) = \log p_0(\bx[0]) +
-      \sum_{n=1}^N \log p(\bx[n] | \bx[n-1],\bu[n-1]) + \sum_{n=0}^n \log
-      p_\alpha(\bu[n] | \bx[n]).$$  Only the last terms depend on $\alpha$,
+      p_0(\bx[0]) \left(\prod_{n=1}^N p\left(\bx[n] \Big{|} \bx[n-1],\bu[n-1]\right) \right)
+      \left(\prod_{n=0}^N p_\alpha(\bu[n] \Big{|} \bx[n]) \right).$$ Taking the $\log$
+      we have $$\log p_\alpha\left(\bx[\cdot],\bu[\cdot]\right) = \log p_0(\bx[0]) +
+      \sum_{n=1}^N \log p(\bx[n] \Big{|} \bx[n-1],\bu[n-1]) + \sum_{n=0}^n \log
+      p_\alpha(\bu[n] \Big{|} \bx[n]).$$  Only the last terms depend on $\alpha$,
       which yields \begin{align*} \frac{\partial}{\partial \alpha} E \left[
       \sum_{n=0}^N \ell(\bx[n], \bu[n]) \right] &= E\left[ \left( \sum_{n=0}^N
       \ell(\bx[n],\bu[n]) \right) \left(\sum_{k=0}^N \frac{\partial}{\partial
-      \alpha} \log p_\alpha(\bu[k]|\bx[k]) \right) \right] \\ &= E\left[
+      \alpha} \log p_\alpha\left(\bu[k]\Big{|}\bx[k]\right) \right) \right] \\ &= E\left[
       \sum_{n=0}^N \left( \ell(\bx[n],\bu[n]) \sum_{k=0}^n
-      \frac{\partial}{\partial \alpha} \log p_\alpha(\bu[k]|\bx[k]) \right)
+      \frac{\partial}{\partial \alpha} \log p_\alpha(\bu[k]\Big{|}\bx[k]) \right)
       \right], \end{align*} where the last step uses the fact that
       $E\left[\ell(\bx[n],\bu[n])\frac{\partial}{\partial \alpha} \log
-      p_\alpha(\bu[k]|\bx[k]) \right] = 0$ for all $k > n$.</p>
+      p_\alpha(\bu[k]\Big{|}\bx[k]) \right] = 0$ for all $k > n$.</p>
 
       <p>This update should surprise you.  It says that I can find the gradient
       of the long-term cost by taking only the gradient of the policy... but not


### PR DESCRIPTION
I had a lot of trouble seeing the conditional expectation bars in the policy gradient so I increased their size

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/underactuated/462)
<!-- Reviewable:end -->
