### PR TITLE
multibody.html: fix contact_stribeck caption

### DIFF
--- a/multibody.html
+++ b/multibody.html
@@ -491,7 +491,7 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture videos a
 
       <figure>
         <img width="90%" src="figures/contact_stribeck.jpg" />
-        <figcaption>(left) The Coloumb friction model.  (right) A continuous piecewise-linear approximation of friction (green) and the <a href="https://drake.mit.edu/doxygen_cxx/group__stribeck__approximation.html">Stribeck approximation of Coloumb friction</a> (blue); the $x$-axis is the contact tangential velocity, and the $y$-axis is the friction coefficient.</figcaption>
+        <figcaption>(left) The Coloumb friction model.  (right) A continuous piecewise-linear approximation of friction (blue) and the <a href="https://drake.mit.edu/doxygen_cxx/group__stribeck__approximation.html">Stribeck approximation of Coloumb friction</a> (green); the $x$-axis is the contact tangential velocity, and the $y$-axis is the friction coefficient.</figcaption>
       </figure>
 
       <p>With these two laws, we can recover the contact forces as relatively


### PR DESCRIPTION
Swap the color labels in the caption for the Stribeck friction model plot to indicate that *blue* is piecewise linear and *green* is the Stribeck model.

![Stribeck friction model plot](https://underactuated.csail.mit.edu/figures/contact_stribeck.jpg)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/underactuated/526)
<!-- Reviewable:end -->
