### PR TITLE
adds missing links to papers in the humanoids section(chapter5)

### DIFF
--- a/humanoids.html
+++ b/humanoids.html
@@ -561,12 +561,14 @@ Robots</h1>
 <span class="author">David E. Orin and Ambarish Goswami and Sung-Hee Lee</span>, 
 <span class="title">"Centroidal dynamics of a humanoid robot"</span>, 
 <span class="publisher">Autonomous Robots</span>, no. September 2012, pp. 1--16, jun, <span class="year">2013</span>.
+[&nbsp;<a href="http://www.ambarish.com/paper/Orin_Goswami_Lee_Centroidal_Dynamics_AURO.pdf">link</a>&nbsp;]
 
 </li><br>
 <li id=Goswami99>
 <span class="author">A. Goswami</span>, 
 <span class="title">"Postural stability of biped robots and the foot rotation indicator ({FRI}) point"</span>, 
 <span class="publisher">International Journal of Robotics Research</span>, vol. 18, no. 6, <span class="year">1999</span>.
+[&nbsp;<a href="http://www.cs.cmu.edu/~cga/legs/Goswami_FRI_IJRR.pdf">link</a>&nbsp;]
 
 </li><br>
 <li id=Deits14a>
@@ -594,6 +596,7 @@ Robots</h1>
 <span class="author">Twan Koolen and Tomas de Boer and John Rebula and Ambarish Goswami and Jerry Pratt</span>, 
 <span class="title">"Capturability-based analysis and control of legged locomotion, Part 1: Theory and application to three simple gait models"</span>, 
 <span class="publisher">The International Journal of Robotics Research</span>, vol. 31, no. 9, pp. 1094-1113, <span class="year">2012</span>.
+[&nbsp;<a href="https://journals.sagepub.com/doi/abs/10.1177/0278364912452673">link</a>&nbsp;]
 
 </li><br>
 <li id=Dai14>


### PR DESCRIPTION
makes it easier for the user to access the papers. Finding a couple of them wasn't super straightforward for me. Hopefully will reduce the friction. Thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/underactuated/530)
<!-- Reviewable:end -->
