### PR TITLE
Fixing elib reference for ilqr assignment

### DIFF
--- a/book/trajopt.html
+++ b/book/trajopt.html
@@ -1396,7 +1396,10 @@ href="https://www.youtube.com/playlist?list=PLkx8KyIQkMfU5szP43GlE_S1QGSPQfL9s">
       first-order systems.  We apply this to second-order systems by
       parameterizing the trajectories for $\bq(t)$ and $\dot{\bq}(t)$ as if
       they were independent, and only link them together through the dynamic
-      constraints (<elib>Junge05</elib>, for instance, discusses how
+      constraints (
+        <note> Savva: i am dropping this elib reference, else elib bugs out with a messed up reference order.
+          The reference here was to Junge05
+        Junge05, for instance, discusses how
       inefficient this can be).  Is there a sweet spot parameterization for
       second-order systems that still gives the third-order integration
       accuracy?  How much of a practical difference does this make for
@@ -1854,12 +1857,6 @@ PhD thesis, Massachusetts Institute of Technology, September, <span class="year"
 <span class="title">"Approximate Hybrid Model Predictive Control for Multi-Contact Push Recovery in Complex Environments"</span>, 
 <span class="publisher">Humanoid Robots (Humanoids), 2017 IEEE-RAS 17th International Conference on</span> , <span class="year">2017</span>.
 [&nbsp;<a href="http://groups.csail.mit.edu/robotics-center/public_papers/Marcucci17.pdf">link</a>&nbsp;]
-
-</li><br>
-<li id=Junge05>
-<span class="author">O. Junge and J. E. Marsden and S. Ober-Bloebaum</span>, 
-<span class="title">"Discrete mechanics and optimal control"</span>, 
-<span class="publisher">Proceedings of the 16th IFAC World Congress</span> , <span class="year">2005</span>.
 
 </li><br>
 <li id=Nganga21>


### PR DESCRIPTION
Hello Russ! It appears that elib has a strange bug, wherein even if the a reference is commented, elib still generates a reference for it, except that messes up the ordering.

You'll see that the reference in assignment 10.3 points to 45, while it should point to 46:  (link)[https://underactuated.mit.edu/trajopt.html#Nganga21].

this seems to occur because elib generates a reference even if the reference is commented out -- this messes up ordering.

I'm pushing a fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/underactuated/552)
<!-- Reviewable:end -->
