### PR TITLE
Fetch bibliography metadata through the shared elib CGI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,10 +178,9 @@ jobs:
             configuration: "--profile black --check-only"
             isort-version: 5.12.0
       - name: autoflake
-        uses: creyD/autoflake_action@master
-        with:
-            options: --remove-all-unused-imports --in-place
-            # Pegging version s.t. https://github.com/creyD/autoflake_action/issues/1
+        run: |
+          python -m pip install autoflake==2.0.2
+          autoflake . --remove-all-unused-imports --in-place
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,5 @@
 
 - Always run Python commands (including tests, linting, type checks, scripts, and tooling) using the repository virtual environment at `.venv`.
 - Prefer `.venv/bin/python -m <tool>` over system Python or globally installed executables.
+- Use the GitHub account `RussTedrake` for this repository; do not use `RussTedrake-walden`.
+- See [docs/hosting.md](docs/hosting.md) before working on the live server.

--- a/book/chapters.json
+++ b/book/chapters.json
@@ -1,4 +1,5 @@
 {
+  "elib_url": "https://underactuated.csail.mit.edu/htmlbook/elib.cgi",
   "chapter_ids" : [
     "intro",
     "pend",

--- a/book/index.html
+++ b/book/index.html
@@ -186,7 +186,7 @@ of Walking and Running</a></li>
         <li>Stance Dynamics</li>
         <li>Foot Collision</li>
         <li>Forward simulation</li>
-        <li>Poincar&eacute Map</li>
+        <li>Poincar&#233; Map</li>
         <li>Fixed Points and Stability</li>
         <li>Stability of standing still</li>
       </ul>

--- a/book/simple_legs.html
+++ b/book/simple_legs.html
@@ -438,7 +438,7 @@ of Walking and Running</h1>
 
       </subsubsection> <!-- end of forward simulation -->
 
-      <subsubsection><h1>Poincar&eacute Map</h1>
+      <subsubsection><h1>Poincar&eacute; Map</h1>
 
         <p>We can now derive the angular velocity at the beginning of each
         stance phase as a function of the angular velocity of the previous

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,0 +1,32 @@
+# CSAIL hosting
+
+The live checkout is `/var/www/underactuated` on
+`underactuated-r1.csail.mit.edu`. Apache serves its `book` directory at
+`https://underactuated.csail.mit.edu/` and enables CGI execution.
+
+SSH first to `login.csail.mit.edu` and complete interactive two-factor
+authentication, then use `ssh -o ProxyJump=none underactuated-r1` for the
+internal hop. The owner has sudo access; deployments require an interactive
+sudo password. Files are managed by `www-data`. Preserve untracked historical
+course directories when updating the checkout.
+
+## Bibliography endpoint
+
+`book/htmlbook/elib.cgi` is shared with the manipulation repository. It is
+served directly at `https://underactuated.csail.mit.edu/htmlbook/elib.cgi` and
+re-executes with this repository's `.venv/bin/python`. Install MySQL
+Connector/Python there (the server deployment uses 9.4.0). The existing `venv`
+is separate and should not be modified for this endpoint.
+
+The CGI reuses `/etc/elib.json` on the VM, owned by `root:www-data` with mode
+640. That file contains the read-only database credentials; keep credentials
+out of the repository and document root. The VM can reach CSAIL MySQL.
+
+The metadata installer reads `elib_url` from `book/chapters.json` and POSTs
+an array of citation tags. The endpoint returns `entries` keyed by tag and a
+`missing` array. It uses parameterized queries, excludes private paper URLs,
+and limits requests to 1000 tags and 128 KiB. Missing records and request
+failures stop the installer before it changes any HTML.
+
+Update the htmlbook submodule reference when adopting shared code changes.
+CGI source updates do not require an Apache restart.


### PR DESCRIPTION
CSAIL MySQL is no longer reachable from outside the CSAIL network. Update htmlbook to the published 966bf1b revision and configure the metadata installer to fetch JSON from https://underactuated.csail.mit.edu/htmlbook/elib.cgi. The shared CGI is deployed on underactuated-r1 and uses the existing server-side database configuration.

Document hosting and GitHub account conventions, and normalize one Poincaré HTML entity in the generated table of contents so the installer leaves the checkout unchanged.

Validation: all 341 citation tags resolved through the live endpoint; normal and --check installer runs exit successfully with no output or changes; all 22 focused CGI and metadata tests pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/underactuated/604)
<!-- Reviewable:end -->
