### PR TITLE
Support Colab Meshcat and prepare 2026.9.8 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         shell: bash
   # TODO(russt): add noble-pip-core workflow which only runs the tests in underactuated, but uses the underactuated module from pip.
   noble-pip-all:
-    name: ubuntu noble using pip all
+    name: ubuntu noble using wheel all
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
     steps:
@@ -118,8 +118,11 @@ jobs:
           # Install system packages as root
           ./setup/ubuntu/24.04/install_prereqs.sh
           apt-get install -o APT::Acquire::Retries=4 -o Dpkg::Use-Pty=0 -qy --no-install-recommends xvfb
-          rm -rf ./underactuated  # remove the local underactuated module, to force using the pip module.
-          sudo -H -u runner python3 -m pip install --user --break-system-packages --upgrade underactuated[all] pytest pytest-timeout
+          # Test this revision's wheel before publishing a release to PyPI.
+          sudo -H -u runner python3 -m pip wheel --no-deps --wheel-dir /tmp/underactuated-wheels .
+          WHEEL_PATH="$(find /tmp/underactuated-wheels -name 'underactuated-*.whl')"
+          sudo -H -u runner python3 -m pip install --user --break-system-packages "${WHEEL_PATH}[all]" pytest pytest-timeout
+          rm -rf ./underactuated  # Force the tests to import the installed wheel.
           rm -rf /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin /var/lib/apt/lists/* /var/log/apt/*
         shell: bash
       - name: test

--- a/book/test_meshcat_colab.py
+++ b/book/test_meshcat_colab.py
@@ -1,0 +1,72 @@
+import logging
+import unittest
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+import underactuated.meshcat_utils as dut
+
+
+class TestMeshcatUtils(unittest.TestCase):
+    def test_display_meshcat_colab_reuses_server(self):
+        colab = ModuleType("google.colab")
+        colab.output = Mock()
+        meshcat = Mock()
+        meshcat.port.return_value = 7002
+        with patch.dict("sys.modules", {"google.colab": colab}):
+            with patch("pydrake.geometry.StartMeshcat") as start:
+                dut.DisplayMeshcat(meshcat, height=450)
+                start.assert_not_called()
+                colab.output.serve_kernel_port_as_iframe.assert_called_once_with(
+                    7002, height=450
+                )
+
+    def test_start_meshcat_local(self):
+        with patch.dict("sys.modules"):
+            dut.sys.modules.pop("google.colab", None)
+            with patch("pydrake.geometry.StartMeshcat") as start:
+                self.assertIs(dut.StartMeshcat(), start.return_value)
+                start.assert_called_once_with()
+
+    def test_start_meshcat_colab(self):
+        colab = ModuleType("google.colab")
+        colab.output = Mock()
+        with patch.dict("sys.modules", {"google.colab": colab}):
+            with patch("pydrake.geometry.StartMeshcat") as start:
+                start.return_value.port.return_value = 7001
+                self.assertIs(dut.StartMeshcat(), start.return_value)
+                start.assert_called_once_with()
+                colab.output.serve_kernel_port_as_window.assert_called_once_with(
+                    7001,
+                    anchor_text="Open Meshcat in a separate window",
+                    skip_warning=True,
+                )
+                colab.output.serve_kernel_port_as_iframe.assert_not_called()
+
+    def test_start_meshcat_colab_filters_only_startup_url(self):
+        colab = ModuleType("google.colab")
+        colab.output = Mock()
+        logger = logging.getLogger("drake")
+        startup = "Meshcat listening for connections at http://localhost:7000"
+
+        def start():
+            logger.info(startup)
+            logger.info("Other information")
+            logger.warning(startup)
+            raise RuntimeError("Startup failed")
+
+        filters_before = list(logger.filters)
+        with patch.dict("sys.modules", {"google.colab": colab}):
+            with patch("pydrake.geometry.StartMeshcat", side_effect=start):
+                with self.assertLogs("drake", level="INFO") as logs:
+                    with self.assertRaisesRegex(RuntimeError, "Startup failed"):
+                        dut.StartMeshcat()
+                    logger.info(startup)
+        self.assertEqual(
+            [(r.levelno, r.getMessage()) for r in logs.records],
+            [
+                (logging.INFO, "Other information"),
+                (logging.WARNING, startup),
+                (logging.INFO, startup),
+            ],
+        )
+        self.assertEqual(logger.filters, filters_before)

--- a/book/test_pytest_collection.py
+++ b/book/test_pytest_collection.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("with_solutions", [False, True])
+def test_collection_respects_ignore_without_private_checkout(tmp_path, with_solutions):
+    conftest = Path(__file__).resolve().parents[1] / "conftest.py"
+    (tmp_path / "conftest.py").write_text(
+        conftest.read_text() + '\ncollect_ignore = ["test_ignored.py"]\n'
+    )
+    (tmp_path / "test_ignored.py").write_text(
+        'raise AssertionError("Ignored modules must not be imported")\n'
+    )
+    (tmp_path / "test_active.py").write_text("def test_active(): pass\n")
+    if with_solutions:
+        (tmp_path / "solutions").mkdir()
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", str(tmp_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "test_active.py::test_active" in result.stdout
+    assert "1 test collected" in result.stdout

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent
 
+# Deepnote projects are retired and will not receive this package release.
+# Remove this exclusion when the Colab migration updates htmlbook, which deletes
+# the obsolete test while also removing the legacy textbook link helpers.
+collect_ignore = ["book/htmlbook/test_check_deepnote_requirements.py"]
+
 
 def pytest_configure() -> None:
     os.environ.setdefault("MPLBACKEND", "Agg")

--- a/conftest.py
+++ b/conftest.py
@@ -28,6 +28,9 @@ def pytest_ignore_collect(collection_path, config):  # type: ignore[no-untyped-d
     if solutions_dir.exists():
         return None
     try:
-        return Path(collection_path).resolve().is_relative_to(solutions_dir)
+        if Path(collection_path).resolve().is_relative_to(solutions_dir):
+            return True
     except Exception:
-        return None
+        pass
+    # Let pytest apply its own collection rules (including collect_ignore).
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "underactuated"
 # Use e.g. 2023.10.4.rc0 if I need to release a release candidate.
 # Use e.g. 2023.10.4.post1 if I need to rerelease on the same day.
-version = "2026.1.2"
+version = "2026.9.8"
 description = "MIT 6.821 - Underactuated Robotics"
 authors = ["Russ Tedrake <russt@mit.edu>"]
 license = "BSD License"

--- a/underactuated/meshcat_utils.py
+++ b/underactuated/meshcat_utils.py
@@ -1,3 +1,5 @@
+import logging
+import sys
 import time
 import typing
 from functools import partial
@@ -20,6 +22,62 @@ from pydrake.systems.framework import Context, EventStatus, LeafSystem
 from pydrake.trajectories import Trajectory
 
 from underactuated import running_as_notebook
+
+
+def StartMeshcat() -> Meshcat:
+    """Starts Meshcat and displays a separate-window link in Google Colab.
+
+    On other platforms, preserves Drake's StartMeshcat behavior. Keep the returned object alive while using the
+    viewer. Use DisplayMeshcat to optionally embed the viewer in Colab.
+    """
+    from pydrake.geometry import StartMeshcat as DrakeStartMeshcat
+
+    if "google.colab" not in sys.modules:
+        return DrakeStartMeshcat()
+
+    from google.colab import output
+
+    # Drake routes its C++ startup message through Python logging. Hide only
+    # the internal URL while constructing the Colab viewer.
+    def hide_meshcat_url(record):
+        return not (
+            record.levelno == logging.INFO
+            and record.getMessage().startswith("Meshcat listening for connections at ")
+        )
+
+    logger = logging.getLogger("drake")
+    logger.addFilter(hide_meshcat_url)
+    try:
+        meshcat = DrakeStartMeshcat()
+    finally:
+        logger.removeFilter(hide_meshcat_url)
+
+    output.serve_kernel_port_as_window(
+        meshcat.port(),
+        anchor_text="Open Meshcat in a separate window",
+        skip_warning=True,
+    )
+    print("Or run DisplayMeshcat(meshcat) to embed it in this notebook.")
+    return meshcat
+
+
+def DisplayMeshcat(meshcat: Meshcat, height: int = 600) -> None:
+    """Displays an existing viewer beside the current notebook cell.
+
+    In Colab, embeds another view of the same Meshcat server. Locally, displays
+    a link that opens the viewer in a separate tab.
+    """
+    if "google.colab" in sys.modules:
+        from google.colab import output
+
+        output.serve_kernel_port_as_iframe(meshcat.port(), height=height)
+    else:
+        from html import escape
+
+        from IPython.display import HTML, display
+
+        url = escape(meshcat.web_url(), quote=True)
+        display(HTML(f'<a href="{url}" target="_blank">Open Meshcat</a>'))
 
 
 # This class is scheduled for removal.  Use meshcat interaction methods instead.


### PR DESCRIPTION
Textbook notebooks need Colab's kernel-port proxy to make Meshcat accessible. Add `StartMeshcat` and `DisplayMeshcat`, following the Manipulation migration, while preserving Drake's behavior outside Colab. Prepare package version 2026.9.8.

This is the package-release prerequisite for #605. Merge and publish the package before merging the follow-up textbook migration.

Validation: four mocked Colab/local helper tests pass on Python 3.13; wheel and sdist build successfully; a fresh wheel installation outside the checkout imports both helpers and passes the Colab proxy smoke test with Drake 1.56.0. Neither artifact contains private exercise sources. The full migration checkout passes all 84 public notebook/helper tests using free solvers.

Follow-up: #607 migrates the textbook once this version is available on PyPI.

CI now builds this revision's wheel before removing the source package and running the pip tests. This tests packaging before publication instead of importing the previous PyPI release. The obsolete Deepnote version check is excluded during this release step; #607 removes that transitional exclusion together with the retired htmlbook test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/underactuated/606)
<!-- Reviewable:end -->
