### PR TITLE
Fix macOS CI Homebrew setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,9 +134,10 @@ jobs:
             --server-args='-screen 0 1280x1024x24 -ac +extension GLX +extension RANDR +render -noreset' \
             python3 -m pytest -ra
         shell: bash
-  sonoma:
-    name: macos sonoma 14
-    runs-on: macos-14
+  sequoia:
+    name: macos sequoia 15
+    # Homebrew's gts dependency no longer provides macOS 14 bottles.
+    runs-on: macos-15
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/setup/mac/Brewfile
+++ b/setup/mac/Brewfile
@@ -3,4 +3,4 @@
 
 brew "python@3.13"
 brew "tidy-html5"
-brew "gprof2dot" # Supplies dot for pydot
+brew "graphviz" # Supplies dot for pydot


### PR DESCRIPTION
The nightly macOS job fails before tests with `gts: no bottle available!` because Homebrew no longer provides a macOS 14 bottle for this Graphviz dependency. Move the runner to macOS 15, which has a supported bottle, and install Graphviz directly instead of pulling it in through gprof2dot.

Failure: https://github.com/RussTedrake/underactuated/actions/runs/34598575153/job/103260065046

Validation: workflow YAML parsing, macOS shell syntax, Brewfile Ruby syntax, and `git diff --check` passed locally. Full CI will run on this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/underactuated/609)
<!-- Reviewable:end -->
