### PR TITLE
Upgrade book rendering to MathJax 4.1.3

### DIFF
--- a/book/acrobot.html
+++ b/book/acrobot.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/actor_critic.html
+++ b/book/actor_critic.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script> 
-    <script type="text/javascript" id="MathJax-script" defer
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="htmlbook/MathJax/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/belief.html
+++ b/book/belief.html
@@ -14,10 +14,7 @@ Uncertainty" content="text/html; charset=utf-8;" />
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/bib.html
+++ b/book/bib.html
@@ -10,9 +10,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script> 
-    <script type="text/javascript" id="MathJax-script" defer
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
-    </script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/contact.html
+++ b/book/contact.html
@@ -14,10 +14,7 @@ Control through Contact" content="text/html; charset=utf-8;" />
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/dp.html
+++ b/book/dp.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/drake.html
+++ b/book/drake.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/feedback_motion_planning.html
+++ b/book/feedback_motion_planning.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/fluids.html
+++ b/book/fluids.html
@@ -10,9 +10,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script> 
-    <script type="text/javascript" id="MathJax-script" defer
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
-    </script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/header.html.in
+++ b/book/header.html.in
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/humanoids.html
+++ b/book/humanoids.html
@@ -14,10 +14,7 @@ Robots" content="text/html; charset=utf-8;" />
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/imitation.html
+++ b/book/imitation.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/index.html
+++ b/book/index.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/intro.html
+++ b/book/intro.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/limit_cycles.html
+++ b/book/limit_cycles.html
@@ -14,10 +14,7 @@ for Limit Cycles" content="text/html; charset=utf-8;" />
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/lqr.html
+++ b/book/lqr.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/lyapunov.html
+++ b/book/lyapunov.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/manipulation.html
+++ b/book/manipulation.html
@@ -10,9 +10,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script> 
-    <script type="text/javascript" id="MathJax-script" defer
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
-    </script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/misc.html
+++ b/book/misc.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/multibody.html
+++ b/book/multibody.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/optimization.html
+++ b/book/optimization.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/output_feedback.html
+++ b/book/output_feedback.html
@@ -14,10 +14,7 @@ Output Feedback (aka Pixels-to-Torques)" content="text/html; charset=utf-8;" />
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/pend.html
+++ b/book/pend.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/planning.html
+++ b/book/planning.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/playbook.html
+++ b/book/playbook.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/policy_search.html
+++ b/book/policy_search.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/rl_policy_search.html
+++ b/book/rl_policy_search.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/robust.html
+++ b/book/robust.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/simple_legs.html
+++ b/book/simple_legs.html
@@ -14,10 +14,7 @@ of Walking and Running" content="text/html; charset=utf-8;" />
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/soft.html
+++ b/book/soft.html
@@ -10,9 +10,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script> 
-    <script type="text/javascript" id="MathJax-script" defer
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
-    </script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/state_estimation.html
+++ b/book/state_estimation.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/stochastic.html
+++ b/book/stochastic.html
@@ -14,10 +14,7 @@ with Stochasticity" content="text/html; charset=utf-8;" />
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/sysid.html
+++ b/book/sysid.html
@@ -12,10 +12,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/trajopt.html
+++ b/book/trajopt.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script>
-    <script type="text/javascript" id="MathJax-script" defer
-      src="htmlbook/MathJax/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/value_learning.html
+++ b/book/value_learning.html
@@ -14,10 +14,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script> 
-    <script type="text/javascript" id="MathJax-script" defer
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
-    </script>
-    <script>window.MathJax || document.write('<script type="text/javascript" src="htmlbook/MathJax/es5/tex-chtml.js" defer><\/script>')</script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/vehicles.html
+++ b/book/vehicles.html
@@ -10,9 +10,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script> 
-    <script type="text/javascript" id="MathJax-script" defer
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
-    </script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->

--- a/book/verification.html
+++ b/book/verification.html
@@ -10,9 +10,7 @@
     <script type="text/javascript" src="notebooks.js"></script>
 
     <script src="htmlbook/mathjax-config.js" defer></script> 
-    <script type="text/javascript" id="MathJax-script" defer
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
-    </script>
+    <script src="htmlbook/mathjax-loader.js" defer></script>
 
     <link rel="stylesheet" href="htmlbook/highlight/styles/default.css">
     <script src="htmlbook/highlight/highlight.pack.js"></script> <!-- http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases -->


### PR DESCRIPTION
Upgrade underactuated to the same MathJax 4.1.3 setup as RussTedrake/manipulation#591. Chapter headers, the index, and older draft pages now use the shared CommonHTML loader with the default New Computer Modern font. The shared htmlbook code waits for asynchronous typesetting before fragment scrolling and HTML capture, and supports a local runtime/font fallback.

The htmlbook update also includes intervening notebook-test changes. Their grading tests hard-coded the manipulation package, causing three failures in underactuated. The two-line fix uses the consuming book's package instead and is merged in https://github.com/RussTedrake/htmlbook/pull/26. The submodule now references merge commit `a22e5d2`, whose contents are identical to the tested revision.

Validation:
- All 36 pages render 4,169 math expressions per browser in macOS Firefox and Chrome, with no MathJax or JavaScript errors.
- LQR fragment scrolling and local MathJax fallback pass; no MathJax CDN requests are made by the fallback.
- The actual HTML capture script preserves all 222 LQR expressions; inspected equation screenshots at multiple CSS scales.
- 49 header-generation/HTML-tidy tests, 6 grading/export tests, and 5 JavaScript loading tests pass.
- The portable grading tests also pass in the manipulation environment.

Ubuntu Firefox and final PrinceXML PDF generation remain unverified. The browser checks above were run locally; existing CI does not run browser-rendering tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/underactuated/611)
<!-- Reviewable:end -->

